### PR TITLE
add refresh all SDK command, plus fixes along the way

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ poetry run hub_utils add-airbyte
 
 ### Update SDK
 
+```
 poetry run hub_utils update-sdk --repo-url https://github.com/MeltanoLabs/tap-snowflake --auto-accept
+```
 
+### Refresh All SDK-based Variants
+
+```
+poetry run hub_utils refresh-sdk-variants --starting-yaml="/_data/meltano/extractors/tap-zendesk-sell/leag.yml"
+```
 
 ## Tests
 

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -1,6 +1,7 @@
 import typer
 from hub_utils.utilities import Utilities
 from typing import Optional
+from hub_utils.yaml_lint import find_all_yamls
 
 app = typer.Typer()
 
@@ -37,10 +38,11 @@ def update(
 @app.command()
 def update_sdk(
     repo_url: str = None,
+    plugin_name: str = None,
     auto_accept: bool = typer.Option(False)
 ):
     util = Utilities(auto_accept)
-    util.update_sdk(repo_url)
+    util.update_sdk(repo_url, plugin_name)
 
 @app.command()
 def add_airbyte(
@@ -49,3 +51,25 @@ def add_airbyte(
 ):
     util = Utilities(auto_accept)
     util.add_airbyte(repo_url)
+
+@app.command()
+def refresh_sdk_variants(
+    starting_yaml: str = None,
+):
+    util = Utilities(True)
+    start = False
+    failures = []
+    for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
+        data = util._read_yaml(yaml_file)
+        if yaml_file == f'{util.hub_root}{starting_yaml}':
+            start = True
+        elif not start:
+            print(f"Skipping SDK based: {yaml_file}")
+            continue
+        if "keywords" in data and "meltano_sdk" in data.get("keywords"):
+            print(f"Updating: {yaml_file}")
+            try:
+                util.update_sdk(data.get('repo'), data.get("name"))
+            except Exception as e:
+                failures.append(yaml_file)
+                print(e)

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -81,6 +81,8 @@ class MeltanoUtil:
                     'Id', 'ID'
                 ).replace(
                     'Db', 'Database'
+                ).replace(
+                    'Api', 'API'
                 )
             )
         return " ".join(new_label)

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -428,9 +428,11 @@ class Utilities:
         sgv
     ):
         new_def = existing_def.copy()
+        # TODO: keep description from existing if not in new
         new_def['settings'] = settings
         new_def['keywords'] = keywords
         new_def['maintenance_status'] = m_status
+        # TODO: clean using an enum, `sync` shouldnt be allowed
         new_def['capabilities'] = caps
         new_def['settings_group_validation'] = sgv
         return new_def
@@ -469,10 +471,10 @@ class Utilities:
         except Exception as e:
             print(e)
 
-    def _update_base(self, repo_url, is_meltano_sdk=False):
+    def _update_base(self, repo_url, plugin_name, is_meltano_sdk=False):
         if not repo_url:
             repo_url = self._prompt("repo_url")
-        plugin_name = self._prompt("plugin name", self._get_plugin_name(repo_url))
+        plugin_name = self._prompt("plugin name", plugin_name or self._get_plugin_name(repo_url))
         plugin_type = self._prompt("plugin type", self.get_plugin_type(repo_url))
         plugin_variant = self._prompt("plugin variant", self._get_plugin_variant(repo_url))
         existing_def = self._retrieve_def(plugin_name, plugin_variant, plugin_type)
@@ -505,8 +507,8 @@ class Utilities:
         self._reformat(plugin_type, plugin_name, plugin_variant)
         print(f'\nUpdates {plugin_type} {plugin_name} ({plugin_variant})\n\n')
 
-    def update_sdk(self, repo_url: str = None, definition_seed: dict = None):
-        repo_url, plugin_name, plugin_type, plugin_variant, existing_def, sdk_def = self._update_base(repo_url, is_meltano_sdk=True)
+    def update_sdk(self, repo_url: str = None, plugin_name: str = None):
+        repo_url, plugin_name, plugin_type, plugin_variant, existing_def, sdk_def = self._update_base(repo_url, plugin_name, is_meltano_sdk=True)
         settings, settings_group_validation, capabilities = MeltanoUtil._parse_sdk_about_settings(sdk_def)
         new_def = self._merge_definitions(
             existing_def,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -323,6 +323,7 @@ def test_airbyte_array_enum_string():
     [
         ["aws_access_key_id", "AWS Access Key ID"],
         ["db_name", "Database Name"],
+        ["api_url", "API URL"],
     ]
 )
 def test_get_label(input, expected):


### PR DESCRIPTION
- command for looping through and updating all SDK variants
- fix case when repo name is mismatch of plugin name i.e. tap-sybase-sdk and the plugin name is tap-sybase. Pass in plugin name also.
- API should be uppercased in labels