### PR TITLE
GitHub action commands

### DIFF
--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -129,6 +129,7 @@ def get_variant_names(
     files = []
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         suffix = yaml_file.replace(f"{hub_root}/_data/meltano/", "")
+        print(f"{yaml_file} -- {suffix}")
         if suffix in select_subset:
             files.append(yaml_file)
     formatted_output = [{"source-name": "/".join(file.split("/")[-3:])} for file in files]

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -190,6 +190,32 @@ def extract_metadata_v2(
         else:
             print(f"Extract already exists: {s3_file_path}")
 
+@app.command()
+def upload_airbyte(
+    variant_path_list: str,
+    artifact_name: str,
+):
+    util = Utilities(True)
+    yaml_file = variant_path_list
+    for yaml_file in variant_path_list.split(","):
+        spec_data = util._read_json(artifact_name)
+        p_type, p_name, p_variant = yaml_file.split("/")[-3:]
+        hash_id = hashlib.md5(json.dumps(spec_data, sort_keys=True, indent=2).encode("utf-8")).hexdigest()
+        file_path = os.path.basename(yaml_file).replace(".yml", "")
+        date_now = datetime.utcnow().strftime("%Y-%m-%d")
+        s3_file_path = f"{p_type}/{p_name}/{file_path}/{hash_id}--{date_now}.json"
+        s3_bucket = os.environ.get(
+            "AWS_S3_BUCKET"
+        )
+        if not S3().hash_exists(s3_bucket, s3_file_path):
+            print(f"Uploading: {s3_file_path}")
+            S3().upload(
+                s3_bucket,
+                s3_file_path,
+                artifact_name
+            )
+        else:
+            print(f"Extract already exists: {s3_file_path}")
 
 @app.command()
 def translate(

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -124,17 +124,15 @@ def get_variant_names(
     # sdk_based: bool = typer.Option(False),
 ):
     select_subset = [
-        "extractors/tap-snowflake/meltanolabs.yml",
-        # "extractors/tap-github/meltanolabs.yml",
-        # "extractors/tap-cloudwatch/meltanolabs.yml"
+        "extractors/tap-cloudwatch/meltanolabs.yml",
     ]
     files = []
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         suffix = yaml_file.replace(f"{hub_root}/_data/meltano/", "")
         if suffix in select_subset:
             files.append(yaml_file)
-    # print(json.dumps(files))
-    print(",".join(files))
+    formatted_output = [{"source-name": "/".join(file.split("/")[-3:])} for file in files]
+    print(json.dumps(formatted_output))
 
 @app.command()
 def extract_metadata_v2(

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -128,7 +128,6 @@ def get_variant_names(
 ):
     formatted_output = []
     util = Utilities(True)
-    count = 0
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         data = util._read_yaml(yaml_file)
         if plugin_type and yaml_file.split("/")[-3] not in plugin_type.split(","):
@@ -148,9 +147,6 @@ def get_variant_names(
             if not image_name:
                 continue
             formatted_output.append({"plugin-name": suffix, "source-name": image_name.replace("airbyte/", "")})
-            count += 1
-            if count > 5:
-                break
     print(json.dumps(formatted_output).replace('\"', '\\"'))
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -116,7 +116,7 @@ def extract_metadata(
 @app.command()
 def get_variant_names(
     hub_root: str,
-    sdk_based: bool = typer.Option(False),
+    # sdk_based: bool = typer.Option(False),
 ):
     select_subset = [
         "extractors/tap-snowflake/meltanolabs.yml",
@@ -128,7 +128,8 @@ def get_variant_names(
         suffix = yaml_file.replace(f"{hub_root}/_data/meltano/", "")
         if suffix in select_subset:
             files.append(yaml_file)
-    print(json.dumps(files))
+    # print(json.dumps(files))
+    print(",".join(files))
 
 @app.command()
 def extract_metadata_v2(
@@ -137,7 +138,7 @@ def extract_metadata_v2(
 ):
     util = Utilities(True)
     failures = []
-    for yaml_file in json.loads(variant_path_list):
+    for yaml_file in variant_path_list.split(","):
         data = util._read_yaml(yaml_file)
         p_type = util.get_plugin_type(data.get("repo"))
         p_name = data.get("name")

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -1,9 +1,14 @@
-import typer
-from hub_utils.utilities import Utilities
-from typing import Optional
-from hub_utils.yaml_lint import find_all_yamls
-import os
 import json
+import os
+from datetime import datetime
+from typing import Optional
+
+import typer
+
+from hub_utils.meltano_util import MeltanoUtil
+from hub_utils.s3 import S3
+from hub_utils.utilities import Utilities
+from hub_utils.yaml_lint import find_all_yamls
 
 app = typer.Typer()
 
@@ -63,7 +68,7 @@ def refresh_sdk_variants(
     failures = []
     for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
         data = util._read_yaml(yaml_file)
-        if yaml_file == f'{util.hub_root}{starting_yaml}':
+        if yaml_file == f"{util.hub_root}{starting_yaml}":
             start = True
         elif not start:
             print(f"Skipping SDK based: {yaml_file}")
@@ -71,7 +76,7 @@ def refresh_sdk_variants(
         if "keywords" in data and "meltano_sdk" in data.get("keywords"):
             print(f"Updating: {yaml_file}")
             try:
-                util.update_sdk(data.get('repo'), data.get("name"))
+                util.update_sdk(data.get("repo"), data.get("name"))
             except Exception as e:
                 failures.append(yaml_file)
                 print(e)
@@ -86,7 +91,7 @@ def extract_metadata(
     failures = []
     for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
         data = util._read_yaml(yaml_file)
-        if not starting_yaml or yaml_file == f'{util.hub_root}{starting_yaml}':
+        if not starting_yaml or yaml_file == f"{util.hub_root}{starting_yaml}":
             start = True
         elif not start:
             print(f"Skipping SDK based: {yaml_file}")
@@ -106,7 +111,7 @@ def extract_metadata(
             if not sdk_def:
                 failures.append(yaml_file)
                 continue
-            file_name = os.path.basename(yaml_file).replace('.yml', '.json')
+            file_name = os.path.basename(yaml_file).replace(".yml", ".json")
             util._write_dict(
                 f"{output_dir}/{p_type}/{p_name}/{file_name}",
                 sdk_def
@@ -153,10 +158,20 @@ def extract_metadata_v2(
         if not sdk_def:
             failures.append(yaml_file)
             continue
-        file_name = os.path.basename(yaml_file).replace('.yml', '.json')
+        file_path = os.path.basename(yaml_file).replace(".yml", "")
+        file_name = file_path + ".json"
+        local_file_path = f"{output_dir}/{p_type}/{p_name}/{file_name}"
         util._write_dict(
-            f"{output_dir}/{p_type}/{p_name}/{file_name}",
+            local_file_path,
             sdk_def
+        )
+        date_now = datetime.utcnow().strftime("%Y-%m-%d")
+        S3().upload(
+            os.environ.get(
+                "AWS_S3_BUCKET"
+            ),
+            f"{p_type}/{p_name}/{file_path}/{date_now}.json",
+            local_file_path
         )
     print(failures)
 
@@ -167,26 +182,32 @@ def translate(
     sdk_output_path: str,
 ):
     util = Utilities(True)
-    from hub_utils.meltano_util import MeltanoUtil
 
     for yaml_file in variant_path_list.split(","):
         existing_def = util._read_yaml(yaml_file)
-        suffix = "/".join(yaml_file.split("/")[-3:])
-        json_file = f"{sdk_output_path}/{suffix}".replace(".yml", ".json")
-        with open(json_file, "r") as f:
+        p_type, p_name, p_variant = yaml_file.split("/")[-3:]
+        p_variant = p_variant.replace(".yml", "")
+        suffix = f"{p_type}/{p_name}/{p_variant}"
+        local_file_path = f"{sdk_output_path}/{suffix}.json"
+        S3().download_latest(
+            os.environ.get(
+                "AWS_S3_BUCKET"
+            ),
+            suffix,
+            local_file_path
+        )
+
+        with open(local_file_path, "r") as f:
             sdk_about = json.load(f)
         settings, settings_group_validation, capabilities = MeltanoUtil._parse_sdk_about_settings(sdk_about)
         new_def = util._merge_definitions(
             existing_def,
             settings,
             util._string_to_literal(util._scrape_keywords(True, existing_def.get("keywords"))),
-            existing_def.get('maintenance_status'),
+            existing_def.get("maintenance_status"),
             capabilities,
             settings_group_validation,
         )
-        p_name = existing_def.get("name")
-        p_type = util.get_plugin_type(existing_def.get("repo"))
-        p_variant = existing_def.get("variant")
         util._write_updated_def(
             p_name,
             p_variant,

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -142,12 +142,11 @@ def extract_metadata_v2(
     output_dir: str,
 ):
     util = Utilities(True)
-    failures = []
     for yaml_file in variant_path_list.split(","):
         data = util._read_yaml(yaml_file)
         p_type = util.get_plugin_type(data.get("repo"))
         p_name = data.get("name")
-        sdk_def = util._test(
+        sdk_def = util._test_exception(
             p_name,
             p_type,
             data.get("pip_url"),
@@ -155,9 +154,6 @@ def extract_metadata_v2(
             data.get("executable", p_name),
             True
         )
-        if not sdk_def:
-            failures.append(yaml_file)
-            continue
         file_path = os.path.basename(yaml_file).replace(".yml", "")
         file_name = file_path + ".json"
         local_file_path = f"{output_dir}/{p_type}/{p_name}/{file_name}"
@@ -173,7 +169,6 @@ def extract_metadata_v2(
             f"{p_type}/{p_name}/{file_path}/{date_now}.json",
             local_file_path
         )
-    print(failures)
 
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -128,6 +128,7 @@ def get_variant_names(
 ):
     formatted_output = []
     util = Utilities(True)
+    count = 0
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         data = util._read_yaml(yaml_file)
         if plugin_type and yaml_file.split("/")[-3] not in plugin_type.split(","):
@@ -147,6 +148,9 @@ def get_variant_names(
             if not image_name:
                 continue
             formatted_output.append({"plugin-name": suffix, "source-name": image_name.replace("airbyte/", "")})
+            count += 1
+            if count > 5:
+                break
     print(json.dumps(formatted_output).replace('\"', '\\"'))
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -137,6 +137,14 @@ def get_variant_names(
             if "meltano_sdk" not in data.get("keywords", []):
                 continue
             suffix = "/".join(yaml_file.split("/")[-3:])
+            # TODO remove this filtering
+            if suffix not in (
+                "extractors/tap-netlify/franloza.yml", # <3.9 test
+                "extractors/tap-twitter/voxmedia.yml",
+                "extractors/tap-sendinblue/hotgluexyz.yml",
+            ):
+                # Testing a subset
+                continue
             formatted_output.append({"plugin-name":suffix})
 
         if metadata_type == "airbyte":

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -218,7 +218,7 @@ def upload_airbyte(
             print(f"Extract already exists: {s3_file_path}")
 
 @app.command()
-def translate(
+def translate_sdk(
     variant_path_list: str,
     sdk_output_path: str,
 ):

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -145,7 +145,6 @@ def get_variant_names(
             suffix = "/".join(yaml_file.split("/")[-3:])
             image_name = [setting.get("value") for setting in data.get("settings") if setting.get("name") == "airbyte_spec.image"][0]
             if not image_name:
-                print(f"Skipping {yaml_file}")
                 continue
             formatted_output.append({"plugin-name": suffix, "source-name": image_name.replace("airbyte/", "")})
     print(json.dumps(formatted_output).replace('\"', '\\"'))

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -3,6 +3,7 @@ from hub_utils.utilities import Utilities
 from typing import Optional
 from hub_utils.yaml_lint import find_all_yamls
 import os
+import json
 
 app = typer.Typer()
 
@@ -92,26 +93,103 @@ def extract_metadata(
             continue
         if "keywords" in data and "meltano_sdk" in data.get("keywords"):
             print(f"Updating: {yaml_file}")
-            try:
-                p_type = util.get_plugin_type(data.get("repo"))
-                p_name = data.get("name")
-                sdk_def = util._test(
-                    p_name,
-                    p_type,
-                    data.get("pip_url"),
-                    data.get("namespace"),
-                    data.get("executable", p_name),
-                    True
-                )
-                if not sdk_def:
-                    failures.append(yaml_file)
-                    continue
-                file_name = os.path.basename(yaml_file).replace('.yml', '.json')
-                util._write_dict(
-                    f"{output_dir}/{p_type}/{p_name}/{file_name}",
-                    sdk_def
-                )
-            except Exception as e:
+            p_type = util.get_plugin_type(data.get("repo"))
+            p_name = data.get("name")
+            sdk_def = util._test(
+                p_name,
+                p_type,
+                data.get("pip_url"),
+                data.get("namespace"),
+                data.get("executable", p_name),
+                True
+            )
+            if not sdk_def:
                 failures.append(yaml_file)
-                print(e)
+                continue
+            file_name = os.path.basename(yaml_file).replace('.yml', '.json')
+            util._write_dict(
+                f"{output_dir}/{p_type}/{p_name}/{file_name}",
+                sdk_def
+            )
     print(failures)
+
+@app.command()
+def get_variant_names(
+    hub_root: str,
+    sdk_based: bool = typer.Option(False),
+):
+    select_subset = [
+        "extractors/tap-snowflake/meltanolabs.yml",
+        "extractors/tap-github/meltanolabs.yml",
+        "extractors/tap-cloudwatch/meltanolabs.yml"
+    ]
+    files = []
+    for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
+        suffix = yaml_file.replace(f"{hub_root}/_data/meltano/", "")
+        if suffix in select_subset:
+            files.append(yaml_file)
+    print(json.dumps(files))
+
+@app.command()
+def extract_metadata_v2(
+    variant_path_list: str,
+    output_dir: str,
+):
+    util = Utilities(True)
+    failures = []
+    for yaml_file in json.loads(variant_path_list):
+        data = util._read_yaml(yaml_file)
+        p_type = util.get_plugin_type(data.get("repo"))
+        p_name = data.get("name")
+        sdk_def = util._test(
+            p_name,
+            p_type,
+            data.get("pip_url"),
+            data.get("namespace"),
+            data.get("executable", p_name),
+            True
+        )
+        if not sdk_def:
+            failures.append(yaml_file)
+            continue
+        file_name = os.path.basename(yaml_file).replace('.yml', '.json')
+        util._write_dict(
+            f"{output_dir}/{p_type}/{p_name}/{file_name}",
+            sdk_def
+        )
+    print(failures)
+
+
+@app.command()
+def translate(
+    variant_path_list: str,
+    sdk_output_path: str,
+):
+    util = Utilities(True)
+    from hub_utils.meltano_util import MeltanoUtil
+
+    for yaml_file in json.loads(variant_path_list):
+        existing_def = util._read_yaml(yaml_file)
+        suffix = "/".join(yaml_file.split("/")[-3:])
+        json_file = f"{sdk_output_path}/{suffix}".replace(".yml", ".json")
+        with open(json_file, "r") as f:
+            sdk_about = json.load(f)
+        settings, settings_group_validation, capabilities = MeltanoUtil._parse_sdk_about_settings(sdk_about)
+        new_def = util._merge_definitions(
+            existing_def,
+            settings,
+            util._string_to_literal(util._scrape_keywords(True, existing_def.get("keywords"))),
+            existing_def.get('maintenance_status'),
+            capabilities,
+            settings_group_validation,
+        )
+        p_name = existing_def.get("name")
+        p_type = util.get_plugin_type(existing_def.get("repo"))
+        p_variant = existing_def.get("variant")
+        util._write_updated_def(
+            p_name,
+            p_variant,
+            p_type,
+            new_def
+        )
+        util._reformat(p_type, p_name, p_variant)

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -120,8 +120,8 @@ def get_variant_names(
 ):
     select_subset = [
         "extractors/tap-snowflake/meltanolabs.yml",
-        "extractors/tap-github/meltanolabs.yml",
-        "extractors/tap-cloudwatch/meltanolabs.yml"
+        # "extractors/tap-github/meltanolabs.yml",
+        # "extractors/tap-cloudwatch/meltanolabs.yml"
     ]
     files = []
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -121,20 +121,11 @@ def extract_metadata(
 @app.command()
 def get_variant_names(
     hub_root: str,
-    # sdk_based: bool = typer.Option(False),
 ):
-    select_subset = [
-        "extractors/tap-cloudwatch/meltanolabs.yml",
-    ]
     files = []
-    # print("starting")
-    # print("YAML" + str(find_all_yamls(f_path=f"{hub_root}/_data/meltano/")))
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
-        suffix = yaml_file.replace(f"{hub_root}/_data/meltano/", "")
-        # print(f"{yaml_file} -- {suffix}")
-        if suffix in select_subset:
-            files.append(yaml_file)
-    formatted_output = [{"source-name": "/".join(file.split("/")[-3:])} for file in files]
+        files.append("/".join(yaml_file.split("/")[-3:]))
+    formatted_output = [{"source-name": suffix} for suffix in files]
     print(json.dumps(formatted_output).replace('\"', '\\"'))
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -137,14 +137,6 @@ def get_variant_names(
             if "meltano_sdk" not in data.get("keywords", []):
                 continue
             suffix = "/".join(yaml_file.split("/")[-3:])
-            # TODO remove this filtering
-            if suffix not in (
-                "extractors/tap-netlify/franloza.yml", # <3.9 test
-                "extractors/tap-twitter/voxmedia.yml",
-                "extractors/tap-sendinblue/hotgluexyz.yml",
-            ):
-                # Testing a subset
-                continue
             formatted_output.append({"plugin-name":suffix})
 
         if metadata_type == "airbyte":

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -122,16 +122,19 @@ def extract_metadata(
 @app.command()
 def get_variant_names(
     hub_root: str,
-    sdk_based: bool = typer.Option(True),
-    plugin_type: str = typer.Option("extractors"),
+    metadata_type: str = typer.Option("sdk"),
+    # comma separated list
+    plugin_type: str = None,
 ):
     files = []
     util = Utilities(True)
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         data = util._read_yaml(yaml_file)
-        if sdk_based and "meltano_sdk" not in data.get("keywords", []):
+        if metadata_type == "sdk" and "meltano_sdk" not in data.get("keywords", []):
             continue
-        if plugin_type and yaml_file.split("/")[-3] != plugin_type:
+        if metadata_type == "airbyte" and "airbyte_protocol" not in data.get("keywords", []):
+            continue
+        if plugin_type and yaml_file.split("/")[-3] not in plugin_type.split(","):
             continue
         files.append("/".join(yaml_file.split("/")[-3:]))
     formatted_output = [{"source-name": suffix} for suffix in files]

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -169,7 +169,7 @@ def translate(
     util = Utilities(True)
     from hub_utils.meltano_util import MeltanoUtil
 
-    for yaml_file in json.loads(variant_path_list):
+    for yaml_file in variant_path_list.split(","):
         existing_def = util._read_yaml(yaml_file)
         suffix = "/".join(yaml_file.split("/")[-3:])
         json_file = f"{sdk_output_path}/{suffix}".replace(".yml", ".json")

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -135,8 +135,7 @@ def get_variant_names(
         if suffix in select_subset:
             files.append(yaml_file)
     formatted_output = [{"source-name": "/".join(file.split("/")[-3:])} for file in files]
-    print(json.dumps(formatted_output))
-    # .replace("\"", "/\""))
+    print(json.dumps(formatted_output).replace('\"', '\\"'))
 
 @app.command()
 def extract_metadata_v2(

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -127,6 +127,8 @@ def get_variant_names(
         "extractors/tap-snowflake/meltanolabs.yml",
     ]
     files = []
+    print("starting")
+    print("YAML" + str(find_all_yamls(f_path=f"{hub_root}/_data/meltano/")))
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         suffix = yaml_file.replace(f"{hub_root}/_data/meltano/", "")
         print(f"{yaml_file} -- {suffix}")

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -124,14 +124,14 @@ def get_variant_names(
     # sdk_based: bool = typer.Option(False),
 ):
     select_subset = [
-        "extractors/tap-snowflake/meltanolabs.yml",
+        "extractors/tap-cloudwatch/meltanolabs.yml",
     ]
     files = []
-    print("starting")
-    print("YAML" + str(find_all_yamls(f_path=f"{hub_root}/_data/meltano/")))
+    # print("starting")
+    # print("YAML" + str(find_all_yamls(f_path=f"{hub_root}/_data/meltano/")))
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         suffix = yaml_file.replace(f"{hub_root}/_data/meltano/", "")
-        print(f"{yaml_file} -- {suffix}")
+        # print(f"{yaml_file} -- {suffix}")
         if suffix in select_subset:
             files.append(yaml_file)
     formatted_output = [{"source-name": "/".join(file.split("/")[-3:])} for file in files]

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -135,7 +135,8 @@ def get_variant_names(
         if suffix in select_subset:
             files.append(yaml_file)
     formatted_output = [{"source-name": "/".join(file.split("/")[-3:])} for file in files]
-    print(json.dumps(formatted_output).replace("\"", "/\""))
+    print(json.dumps(formatted_output))
+    # .replace("\"", "/\""))
 
 @app.command()
 def extract_metadata_v2(

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -126,18 +126,25 @@ def get_variant_names(
     # comma separated list
     plugin_type: str = None,
 ):
-    files = []
+    formatted_output = []
     util = Utilities(True)
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
         data = util._read_yaml(yaml_file)
-        if metadata_type == "sdk" and "meltano_sdk" not in data.get("keywords", []):
-            continue
-        if metadata_type == "airbyte" and "airbyte_protocol" not in data.get("keywords", []):
-            continue
         if plugin_type and yaml_file.split("/")[-3] not in plugin_type.split(","):
             continue
-        files.append("/".join(yaml_file.split("/")[-3:]))
-    formatted_output = [{"source-name": suffix} for suffix in files]
+
+        if metadata_type == "sdk":
+            if "meltano_sdk" not in data.get("keywords", []):
+                continue
+            suffix = "/".join(yaml_file.split("/")[-3:])
+            formatted_output.append({"plugin-name":suffix})
+
+        if metadata_type == "airbyte":
+            if "airbyte_protocol" not in data.get("keywords", []):
+                continue
+            suffix = "/".join(yaml_file.split("/")[-3:])
+            image_name = [setting.get("value") for setting in data.get("settings") if setting.get("name") == "airbyte_spec.image"][0]
+            formatted_output.append({"plugin-name": suffix, "image-name": image_name})
     print(json.dumps(formatted_output).replace('\"', '\\"'))
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -124,7 +124,7 @@ def get_variant_names(
     # sdk_based: bool = typer.Option(False),
 ):
     select_subset = [
-        "extractors/tap-cloudwatch/meltanolabs.yml",
+        "extractors/tap-snowflake/meltanolabs.yml",
     ]
     files = []
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
@@ -132,7 +132,7 @@ def get_variant_names(
         if suffix in select_subset:
             files.append(yaml_file)
     formatted_output = [{"source-name": "/".join(file.split("/")[-3:])} for file in files]
-    print(json.dumps(formatted_output))
+    print(json.dumps(formatted_output).replace("\"", "/\""))
 
 @app.command()
 def extract_metadata_v2(

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -144,7 +144,10 @@ def get_variant_names(
                 continue
             suffix = "/".join(yaml_file.split("/")[-3:])
             image_name = [setting.get("value") for setting in data.get("settings") if setting.get("name") == "airbyte_spec.image"][0]
-            formatted_output.append({"plugin-name": suffix, "image-name": image_name})
+            if not image_name:
+                print(f"Skipping {yaml_file}")
+                continue
+            formatted_output.append({"plugin-name": suffix, "source-name": image_name.replace("airbyte/", "")})
     print(json.dumps(formatted_output).replace('\"', '\\"'))
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -121,9 +121,17 @@ def extract_metadata(
 @app.command()
 def get_variant_names(
     hub_root: str,
+    sdk_based: bool = typer.Option(True),
+    plugin_type: str = typer.Option("extractors"),
 ):
     files = []
+    util = Utilities(True)
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
+        data = util._read_yaml(yaml_file)
+        if sdk_based and "meltano_sdk" not in data.get("keywords", []):
+            continue
+        if plugin_type and yaml_file.split("/")[-3] != plugin_type:
+            continue
         files.append("/".join(yaml_file.split("/")[-3:]))
     formatted_output = [{"source-name": suffix} for suffix in files]
     print(json.dumps(formatted_output).replace('\"', '\\"'))

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -150,7 +150,7 @@ def get_variant_names(
     print(json.dumps(formatted_output).replace('\"', '\\"'))
 
 @app.command()
-def extract_metadata_v2(
+def extract_sdk_metadata_to_s3(
     variant_path_list: str,
     output_dir: str,
 ):

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -17,13 +17,14 @@ class MeltanoUtil:
 
     @staticmethod
     def add(plugin_name, namespace, executable, pip_url, plugin_type):
+        python_version = subprocess.run("which python".split(" "), stdout=subprocess.PIPE, universal_newlines=True).stdout.replace("\n", "")
         subprocess.run(
             f'pipx uninstall {plugin_name}'.split(" "),
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )
         subprocess.run(
-            f'pipx install {pip_url} --python $(which python)'.split(" "),
+            f'pipx install {pip_url} --python {python_version}'.split(" "),
             stdout=subprocess.PIPE,
             universal_newlines=True,
             check=True,

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -23,7 +23,7 @@ class MeltanoUtil:
             universal_newlines=True,
         )
         subprocess.run(
-            f'pipx install {pip_url}'.split(" "),
+            f'pipx install {pip_url} --python $(which python)'.split(" "),
             stdout=subprocess.PIPE,
             universal_newlines=True,
             check=True,

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -18,6 +18,11 @@ class MeltanoUtil:
     @staticmethod
     def add(plugin_name, namespace, executable, pip_url, plugin_type):
         subprocess.run(
+            f'pipx uninstall {plugin_name}'.split(" "),
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        subprocess.run(
             f'pipx install {pip_url}'.split(" "),
             stdout=subprocess.PIPE,
             universal_newlines=True,

--- a/hub_utils/s3.py
+++ b/hub_utils/s3.py
@@ -1,0 +1,45 @@
+import os
+import boto3
+from pathlib import Path
+
+class S3:
+
+    def __init__(self):
+        self._client = self._create_client()
+
+    def _create_client(self):
+        aws_access_key_id = os.environ.get(
+            "AWS_ACCESS_KEY_ID"
+        )
+        aws_secret_access_key = os.environ.get(
+            "AWS_SECRET_ACCESS_KEY"
+        )
+        aws_session_token = os.environ.get(
+            "AWS_SESSION_TOKEN"
+        )
+        aws_profile = os.environ.get("AWS_PROFILE")
+
+        # AWS credentials based authentication
+        if aws_access_key_id and aws_secret_access_key:
+            aws_session = boto3.session.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+                # region_name=aws_region_name,
+            )
+        else:
+            aws_session = boto3.session.Session(profile_name=aws_profile)
+        s3 = aws_session.client("s3")
+        return s3
+
+    def upload(self, bucket, prefix, local_file_path):
+        self._client.upload_file(local_file_path, bucket, prefix)
+
+    def download_latest(self, bucket, prefix, local_file_path):
+        objs = self._client.list_objects_v2(Bucket=bucket, Prefix=prefix)['Contents']
+        latest = sorted([os.path.basename(obj["Key"]).replace(".json", "") for obj in objs])[-1]
+        Path(os.path.dirname(local_file_path)).mkdir(parents=True, exist_ok=True)
+        self._client.download_file(bucket, f"{prefix}/{latest}.json", local_file_path)
+
+    def get_latest(self, bucket, prefix, local_file_path):
+        self._client.download_file(bucket, prefix, local_file_path)

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -491,17 +491,21 @@ class Utilities:
         new_def['settings_group_validation'] = sgv
         return new_def
 
+    def _test_exception(self, plugin_name, plugin_type, pip_url, namespace, executable, is_meltano_sdk):
+        if self._prompt("Run install test?", True, type=bool):
+            self._install_test(plugin_name, plugin_type, pip_url, namespace, executable)
+        if is_meltano_sdk:
+            if self._prompt("Scrape SDK --about settings?", True, type=bool):
+                try:
+                    return MeltanoUtil.sdk_about(plugin_name)
+                except Exception as e:
+                    if self._prompt("Scrape failed! Provide as json?", True, type=bool):
+                        return json.loads(self._prompt("Provide --about output"))
+
+
     def _test(self, plugin_name, plugin_type, pip_url, namespace, executable, is_meltano_sdk):
         try:
-            if self._prompt("Run install test?", True, type=bool):
-                self._install_test(plugin_name, plugin_type, pip_url, namespace, executable)
-            if is_meltano_sdk:
-                if self._prompt("Scrape SDK --about settings?", True, type=bool):
-                    try:
-                        return MeltanoUtil.sdk_about(plugin_name)
-                    except Exception as e:
-                        if self._prompt("Scrape failed! Provide as json?", True, type=bool):
-                            return json.loads(self._prompt("Provide --about output"))
+            self._test_exception(plugin_name, plugin_type, pip_url, namespace, executable, is_meltano_sdk)
         except Exception as e:
             print(e)
 

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -80,6 +80,11 @@ class Utilities:
             data = self.yaml.load(f)
         return data
 
+    def _read_json(self, path):
+        with open(path, "r") as f:
+            data = json.load(f)
+        return data
+
     @staticmethod
     def _get_plugin_name(repo_url: str):
         return repo_url.split("/")[-1]

--- a/poetry.lock
+++ b/poetry.lock
@@ -214,6 +214,38 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "boto3"
+version = "1.26.96"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+
+[package.dependencies]
+botocore = ">=1.29.96,<1.30.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.6.0,<0.7.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.29.96"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.16.9)"]
+
+[[package]]
 name = "cached-property"
 version = "1.5.2"
 description = "A decorator for caching properties in classes."
@@ -250,6 +282,25 @@ python-versions = ">=3.6.0"
 
 [package.extras]
 unicode-backport = ["unicodedata2"]
+
+[[package]]
+name = "check-jsonschema"
+version = "0.21.0"
+description = "A jsonschema CLI and pre-commit hook"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8,<9"
+importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
+jsonschema = ">=4,<5.0"
+requests = "<3.0"
+"ruamel.yaml" = "0.17.21"
+
+[package.extras]
+dev = ["coverage (<8)", "pytest (<8)", "pytest-xdist (<4)", "responses (==0.22.0)"]
+docs = ["furo (==2022.12.07)", "sphinx (<7)", "sphinx-issues (<4)"]
 
 [[package]]
 name = "click"
@@ -323,6 +374,14 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
 [[package]]
+name = "distlib"
+version = "0.3.6"
+description = "Distribution utilities"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "dnspython"
 version = "2.2.1"
 description = "DNS toolkit"
@@ -357,6 +416,18 @@ description = "A python package that provides useful locks"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "filelock"
+version = "3.10.0"
+description = "A platform independent file lock."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.1)", "pytest (>=7.2.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flask"
@@ -587,7 +658,7 @@ testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packag
 
 [[package]]
 name = "importlib-resources"
-version = "5.10.0"
+version = "5.12.0"
 description = "Read resources from Python packages"
 category = "main"
 optional = false
@@ -597,7 +668,7 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
@@ -631,8 +702,16 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "jsonschema"
-version = "4.16.0"
+version = "4.17.3"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = false
@@ -665,20 +744,6 @@ lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
-name = "markdown"
-version = "3.4.1"
-description = "Python implementation of Markdown."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
-
-[package.extras]
-testing = ["coverage", "pyyaml"]
-
-[[package]]
 name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -688,11 +753,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "meltano"
-version = "2.7.2"
-description = "Meltano: Your DataOps Platform Infrastructure"
+version = "2.17.0"
+description = "Meltano is your CLI for ELT+: Open Source, Flexible, and Scalable. Move, transform, and test your data with confidence using a streamlined data engineering workflow you’ll love."
 category = "main"
 optional = false
-python-versions = ">=3.7,<3.11"
+python-versions = ">=3.7,<3.12"
 
 [package.dependencies]
 aiodocker = ">=0.21.0,<0.22.0"
@@ -703,6 +768,7 @@ authlib = ">=1.0.1,<2.0.0"
 backoff = ">=2.1.2,<3.0.0"
 bcrypt = ">=3.2.0,<4.0.0"
 cached-property = ">=1,<2"
+check-jsonschema = ">=0.21.0,<0.22.0"
 click = ">=8.1,<9.0"
 click-default-group = ">=1.2.1,<2.0.0"
 croniter = ">=1.3.5,<2.0.0"
@@ -716,8 +782,8 @@ flask-restful = ">=0.3.7,<0.4.0"
 flask-sqlalchemy = ">=2.4.4,<3.0.0"
 flatten-dict = ">=0,<1"
 gunicorn = ">=20.1.0,<21.0.0"
-jsonschema = ">=4.9,<5.0"
-markdown = ">=3.3.7,<4.0.0"
+importlib-resources = {version = ">=5.10.1,<6.0.0", markers = "python_version < \"3.9\""}
+jsonschema = ">=4.17,<5.0"
 meltano-flask-security = ">=0.1.0,<0.2.0"
 packaging = ">=21.3,<22.0"
 psutil = ">=5.6.3,<6.0.0"
@@ -729,16 +795,21 @@ pyyaml = ">=6.0.0,<7.0.0"
 requests = ">=2.23.0,<3.0.0"
 rich = ">=12.5.1,<13.0.0"
 "ruamel.yaml" = ">=0.17.21,<0.18.0"
+smart-open = ">=6.2.0,<7.0.0"
 smtpapi = ">=0.4.1,<0.5.0"
 snowplow-tracker = ">=0.10.0,<0.11.0"
 sqlalchemy = ">=1.3.19,<2.0.0"
 structlog = ">=21.2.0,<22.0.0"
 tzlocal = ">=4.2.0,<5.0.0"
 uvicorn = {version = ">=0.17.6,<0.18.0", extras = ["standard"]}
+virtualenv = ">=20.17.1,<21.0.0"
 werkzeug = ">=2.1,<=2.1.3"
 
 [package.extras]
+azure = ["azure-common (>=1.1.28,<2.0.0)", "azure-core (>=1.26.0,<2.0.0)", "azure-storage-blob (>=12.14.1,<13.0.0)"]
+gcs = ["google-cloud-storage (>=1.31.0)"]
 mssql = ["pymssql (>=2.2.5,<3.0.0)"]
+s3 = ["boto3 (>=1.25.3,<2.0.0)"]
 
 [[package]]
 name = "meltano-flask-security"
@@ -824,7 +895,7 @@ python-versions = ">=3.6"
 name = "platformdirs"
 version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1072,6 +1143,20 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "s3transfer"
+version = "0.6.0"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = ">= 3.7"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+
+[[package]]
 name = "setuptools"
 version = "65.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1099,6 +1184,24 @@ description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "smart-open"
+version = "6.3.0"
+description = "Utils for streaming large files (S3, HDFS, GCS, Azure Blob Storage, gzip, bz2...)"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.extras]
+all = ["azure-common", "azure-core", "azure-storage-blob", "boto3", "google-cloud-storage (>=2.6.0)", "paramiko", "requests"]
+azure = ["azure-common", "azure-core", "azure-storage-blob"]
+gcs = ["google-cloud-storage (>=2.6.0)"]
+http = ["requests"]
+s3 = ["boto3"]
+ssh = ["paramiko"]
+test = ["azure-common", "azure-core", "azure-storage-blob", "boto3", "google-cloud-storage (>=2.6.0)", "moto[server]", "paramiko", "pytest", "pytest-rerunfailures", "requests", "responses"]
+webhdfs = ["requests"]
 
 [[package]]
 name = "smtpapi"
@@ -1296,6 +1399,23 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxc
 test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=22.0.0,<22.1.0)", "pycodestyle (>=2.7.0,<2.8.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.21.0"
+description = "Virtual Python Environment builder"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+distlib = ">=0.3.6,<1"
+filelock = ">=3.4.1,<4"
+platformdirs = ">=2.4,<4"
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23)", "pytest (>=7.2.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)"]
+
+[[package]]
 name = "watchgod"
 version = "0.8.2"
 description = "Simple, modern file watching and code reload in python."
@@ -1379,7 +1499,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "173f8e67bbc464d6bbe8fb21af1bf18a67d83ee3f94fce78f4bc6c867386d927"
+content-hash = "399d7b3a9df216948942ed33cc97ab898b8b67b08c85d57087de17fe39beb138"
 
 [metadata.files]
 aiodocker = [
@@ -1576,6 +1696,14 @@ blinker = [
     {file = "blinker-1.5-py2.py3-none-any.whl", hash = "sha256:1eb563df6fdbc39eeddc177d953203f99f097e9bf0e2b8f9f3cf18b6ca425e36"},
     {file = "blinker-1.5.tar.gz", hash = "sha256:923e5e2f69c155f2cc42dafbbd70e16e3fde24d2d4aa2ab72fbe386238892462"},
 ]
+boto3 = [
+    {file = "boto3-1.26.96-py3-none-any.whl", hash = "sha256:f961aa704bd7aeefc186ede52cabc3ef4c336979bb4098d3aad7ca922d55fc27"},
+    {file = "boto3-1.26.96.tar.gz", hash = "sha256:7017102c58b9984749bef3b9f476940593c311504354b9ee9dd7bb0b4657a77d"},
+]
+botocore = [
+    {file = "botocore-1.29.96-py3-none-any.whl", hash = "sha256:c449d7050e9bc4a8b8a62ae492cbdc931b786bf5752b792867f1276967fadaed"},
+    {file = "botocore-1.29.96.tar.gz", hash = "sha256:b9781108810e33f8406942c3e3aab748650c59d5cddb7c9d323f4e2682e7b0b6"},
+]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
     {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
@@ -1654,6 +1782,10 @@ charset-normalizer = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
     {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
 ]
+check-jsonschema = [
+    {file = "check-jsonschema-0.21.0.tar.gz", hash = "sha256:691579e3c849af01e7a15e17c0ef39b85c68395a214dffa3bd92a8be99021744"},
+    {file = "check_jsonschema-0.21.0-py3-none-any.whl", hash = "sha256:f7b232ddfaced917dc75b932b8ed9e52ab603fd455c8af72e0cd04586f7b968a"},
+]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -1701,6 +1833,10 @@ cryptography = [
     {file = "cryptography-38.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b"},
     {file = "cryptography-38.0.1.tar.gz", hash = "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7"},
 ]
+distlib = [
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
 dnspython = [
     {file = "dnspython-2.2.1-py3-none-any.whl", hash = "sha256:a851e51367fb93e9e1361732c1d60dab63eff98712e503ea7d92e6eccb109b4f"},
     {file = "dnspython-2.2.1.tar.gz", hash = "sha256:0f7569a4a6ff151958b64304071d370daa3243d15941a7beedf0c9fe5105603e"},
@@ -1712,6 +1848,10 @@ email-validator = [
 fasteners = [
     {file = "fasteners-0.17.3-py3-none-any.whl", hash = "sha256:cae0772df265923e71435cc5057840138f4e8b6302f888a567d06ed8e1cbca03"},
     {file = "fasteners-0.17.3.tar.gz", hash = "sha256:a9a42a208573d4074c77d041447336cf4e3c1389a256fd3e113ef59cf29b7980"},
+]
+filelock = [
+    {file = "filelock-3.10.0-py3-none-any.whl", hash = "sha256:e90b34656470756edf8b19656785c5fea73afa1953f3e1b0d645cef11cab3182"},
+    {file = "filelock-3.10.0.tar.gz", hash = "sha256:3199fd0d3faea8b911be52b663dfccceb84c95949dd13179aa21436d1a79c4ce"},
 ]
 flask = [
     {file = "Flask-2.1.3-py3-none-any.whl", hash = "sha256:9013281a7402ad527f8fd56375164f3aa021ecfaff89bfe3825346c24f87e04c"},
@@ -1944,8 +2084,8 @@ importlib-metadata = [
     {file = "importlib_metadata-5.0.0.tar.gz", hash = "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.10.0-py3-none-any.whl", hash = "sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437"},
-    {file = "importlib_resources-5.10.0.tar.gz", hash = "sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668"},
+    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
+    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1959,17 +2099,17 @@ jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
+jmespath = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
 jsonschema = [
-    {file = "jsonschema-4.16.0-py3-none-any.whl", hash = "sha256:9e74b8f9738d6a946d70705dc692b74b5429cd0960d58e79ffecfc43b2221eb9"},
-    {file = "jsonschema-4.16.0.tar.gz", hash = "sha256:165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23"},
+    {file = "jsonschema-4.17.3-py3-none-any.whl", hash = "sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6"},
+    {file = "jsonschema-4.17.3.tar.gz", hash = "sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d"},
 ]
 mako = [
     {file = "Mako-1.2.3-py3-none-any.whl", hash = "sha256:c413a086e38cd885088d5e165305ee8eed04e8b3f8f62df343480da0a385735f"},
     {file = "Mako-1.2.3.tar.gz", hash = "sha256:7fde96466fcfeedb0eed94f187f20b23d85e4cb41444be0e542e2c8c65c396cd"},
-]
-markdown = [
-    {file = "Markdown-3.4.1-py3-none-any.whl", hash = "sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186"},
-    {file = "Markdown-3.4.1.tar.gz", hash = "sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
@@ -2014,8 +2154,8 @@ markupsafe = [
     {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
 ]
 meltano = [
-    {file = "meltano-2.7.2-py3-none-any.whl", hash = "sha256:50591e1d387665863a4b83d43e61c30697aca61580fdf9b7bc1f954997f6bf94"},
-    {file = "meltano-2.7.2.tar.gz", hash = "sha256:a7994adcff7f15f4fdd3ef9470eff683cc656685418c1a4123c8159033d970ff"},
+    {file = "meltano-2.17.0-py3-none-any.whl", hash = "sha256:5abd496cc2c0126708012c4541a6f3493dbc4e3e34a547ac8b680102ebb4d37a"},
+    {file = "meltano-2.17.0.tar.gz", hash = "sha256:55de27dbf213673dc844c588ceed86df1f4584d733e820341e35f5c147f7afba"},
 ]
 meltano-flask-security = [
     {file = "meltano-flask-security-0.1.0.tar.gz", hash = "sha256:5926152dc424a764825517ca3530a9bdbc367b7e56cc09ad9ec6510961d6c2cc"},
@@ -2361,6 +2501,10 @@ ruamel-yaml-clib = [
     {file = "ruamel.yaml.clib-0.2.6-cp39-cp39-win_amd64.whl", hash = "sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7"},
     {file = "ruamel.yaml.clib-0.2.6.tar.gz", hash = "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd"},
 ]
+s3transfer = [
+    {file = "s3transfer-0.6.0-py3-none-any.whl", hash = "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd"},
+    {file = "s3transfer-0.6.0.tar.gz", hash = "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"},
+]
 setuptools = [
     {file = "setuptools-65.5.0-py3-none-any.whl", hash = "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"},
     {file = "setuptools-65.5.0.tar.gz", hash = "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17"},
@@ -2372,6 +2516,10 @@ shellingham = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+smart-open = [
+    {file = "smart_open-6.3.0-py3-none-any.whl", hash = "sha256:b4c9ae193ad6d3e7add50944b86afa0d150bd821ab8ec21edb26d9a06b66f6a8"},
+    {file = "smart_open-6.3.0.tar.gz", hash = "sha256:d5238825fe9a9340645fac3d75b287c08fbb99fb2b422477de781c9f5f09e019"},
 ]
 smtpapi = [
     {file = "smtpapi-0.4.12-py3-none-any.whl", hash = "sha256:6ac5a8a7380e5fe689bdf2270acf78b1cb3dfbde73c5fd9e457702626b38e145"},
@@ -2494,6 +2642,10 @@ uvloop = [
     {file = "uvloop-0.17.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c092a2c1e736086d59ac8e41f9c98f26bbf9b9222a76f21af9dfe949b99b2eb9"},
     {file = "uvloop-0.17.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:30babd84706115626ea78ea5dbc7dd8d0d01a2e9f9b306d24ca4ed5796c66ded"},
     {file = "uvloop-0.17.0.tar.gz", hash = "sha256:0ddf6baf9cf11a1a22c71487f39f15b2cf78eb5bde7e5b45fbb99e8a9d91b9e1"},
+]
+virtualenv = [
+    {file = "virtualenv-20.21.0-py3-none-any.whl", hash = "sha256:31712f8f2a17bd06234fa97fdf19609e789dd4e3e4bf108c3da71d710651adbc"},
+    {file = "virtualenv-20.21.0.tar.gz", hash = "sha256:f50e3e60f990a0757c9b68333c9fdaa72d7188caa417f96af9e52407831a3b68"},
 ]
 watchgod = [
     {file = "watchgod-0.8.2-py3-none-any.whl", hash = "sha256:2f3e8137d98f493ff58af54ea00f4d1433a6afe2ed08ab331a657df468c6bfce"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ typer = {extras = ["all"], version = "^0.6.1"}
 ruamel-yaml = "^0.17.21"
 meltano = "^2.11.1"
 yamllint = "^1.28.0"
+boto3 = "^1.26.96"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/sample.sh
+++ b/sample.sh
@@ -1,0 +1,6 @@
+hub_root='/Users/pnadolny/Documents/Git/GitHub/meltano/hub'
+json_output_path='/Users/pnadolny/Documents/Git/GitHub/pnadolny/hub-utils/data'
+sdk_variants=$(poetry run hub_utils get-variant-names $hub_root)
+poetry run hub_utils extract-metadata-v2 "${sdk_variants}" $json_output_path
+echo "Uploading to S3..."
+poetry run hub_utils translate "${sdk_variants}" $json_output_path


### PR DESCRIPTION
Commands used by actions in https://github.com/pnadolny13/hub/blob/action_dev_v2/.github/workflows/metadata-extract.yml to extract all metadata https://github.com/pnadolny13/hub/actions/runs/4511833174


- adds commands needed by github actions
  - get variants list: iterates the hub directory and gets a clean list of variants of a specific type (SDK or Airbyte) and returns in a format that Github actions can accept and use as a matrix input
  - extract_sdk_metadata_to_s3: pipx installs plugin, runs --about, uploads output to S3 if hash doesnt exist
  - upload_airbyte: github actions would have already extracted the spec json so this accepts it as a file input then uploads to S3 if the hash doesnt exist already
  - translate_sdk: retrieves the S3 --about output for SDK variants, reads the local hub yaml definition, merges the two, then writes it back to the yaml file. This needs more work but its most of the way there. I found some cases where the hub descriptions were much more detailed and we overwrite them which is wrong.
- originally the `_test` method was for iterating all variants on the CLI so I wanted failures to log and skip but in github actions I want to know which ones failed so now there `_test_exeception` and `_test` that have the same core behavior but one raise and exception and the other doesnt.