### PR TITLE
add update_quality command

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      HUB_ROOT_PATH: $GITHUB_WORKSPACE/hub_repo/hub"
+      HUB_ROOT_PATH: $GITHUB_WORKSPACE/hub_repo/hub
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      HUB_ROOT_PATH: "${{ vars.GITHUB_WORKSPACE }}/hub_repo/hub"
+      HUB_ROOT_PATH: $GITHUB_WORKSPACE/hub_repo/hub"
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: meltano/hub
-        path: ${{ github.GITHUB_WORKSPACE }}/hub_repo
+        path: $GITHUB_WORKSPACE/hub_repo
         ref: main
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.2.*
-    - name: Clone supercharge docs repository
+    - name: Clone Hub repository
       uses: actions/checkout@v2
       with:
         repository: meltano/hub

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      HUB_ROOT_PATH: "${GITHUB_WORKSPACE}/hub_repo/hub"
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -53,11 +52,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: meltano/hub
-        path: "${GITHUB_WORKSPACE}/hub_repo"
+        path: '${{secrets.GITHUB_WORKSPACE }}/hub_repo'
         ref: main
     - name: Install dependencies
       run: |
         poetry install
     - name: Test with pytest
       run: |
-        poetry run tox -e pytest
+        HUB_ROOT_PATH=$GITHUB_WORKSPACE poetry run tox -e pytest

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: meltano/hub
-        path: ${{ vars.GITHUB_WORKSPACE }}/hub_repo
+        path: ${{ github.GITHUB_WORKSPACE }}/hub_repo
         ref: main
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -52,11 +52,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: meltano/hub
-        path: '${{secrets.GITHUB_WORKSPACE }}/hub_repo'
+        path: hub_repo
         ref: main
     - name: Install dependencies
       run: |
         poetry install
     - name: Test with pytest
       run: |
-        HUB_ROOT_PATH=$GITHUB_WORKSPACE poetry run tox -e pytest
+        HUB_ROOT_PATH=$GITHUB_WORKSPACE/hub_repo poetry run tox -e pytest

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      HUB_ROOT_PATH: $GITHUB_WORKSPACE/hub_repo/hub
+      HUB_ROOT_PATH: "${GITHUB_WORKSPACE}/hub_repo/hub"
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: meltano/hub
-        path: $GITHUB_WORKSPACE/hub_repo
+        path: "${GITHUB_WORKSPACE}/hub_repo"
         ref: main
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      HUB_ROOT_PATH: "/tmp"
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -49,6 +49,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.2.*
+    - name: Install dependencies
+      run: |
+        git clone https://github.com/meltano/hub.git /tmp
     - name: Install dependencies
       run: |
         poetry install

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      HUB_ROOT_PATH: "/usr/local/hub_repo/hub"
+      HUB_ROOT_PATH: "${{ vars.GITHUB_WORKSPACE }}/hub_repo/hub"
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -49,9 +49,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.2.*
-    - name: Install dependencies
-      run: |
-        git clone https://github.com/meltano/hub.git /usr/local/hub_repo/
+    - name: Clone supercharge docs repository
+      uses: actions/checkout@v2
+      with:
+        repository: meltano/hub
+        path: ${{ vars.GITHUB_WORKSPACE }}/hub_repo
+        ref: main
     - name: Install dependencies
       run: |
         poetry install

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      HUB_ROOT_PATH: "/tmp"
+      HUB_ROOT_PATH: "/usr/local/hub_repo/hub"
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
@@ -51,7 +51,7 @@ jobs:
         pip install poetry==1.2.*
     - name: Install dependencies
       run: |
-        git clone https://github.com/meltano/hub.git /tmp
+        git clone https://github.com/meltano/hub.git /usr/local/hub_repo/
     - name: Install dependencies
       run: |
         poetry install

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -75,7 +75,7 @@ def update_quality(
     metrics_file_path: str,
 ):
     util = Utilities(True)
-    usage_metrics = util._read_yaml(metrics_file_path)
+    usage_metrics = util._read_yaml(metrics_file_path)["metrics"]
     for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
         if yaml_file.split("/")[-3] not in ("extractors", "loaders"):
             continue

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -69,6 +69,7 @@ def update_sdk(
     util = Utilities(auto_accept)
     util.update_sdk(repo_url, plugin_name)
 
+
 @app.command()
 def update_quality(
     metrics_file_path: str,
@@ -78,14 +79,17 @@ def update_quality(
     for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
         data = util._read_yaml(yaml_file)
         is_sdk_based = False
-        
+
         if "keywords" in data and "meltano_sdk" in data.get("keywords"):
             is_sdk_based = True
         usage_count = usage_metrics.get(data["repo"], {}).get("ALL_PROJECTS", 0)
         # TODO: Calculate responsiveness
         responsiveness = "high"
-        data["quality"] = MeltanoUtil.get_quality(data["variant"], is_sdk_based, usage_count, responsiveness)
+        data["quality"] = MeltanoUtil.get_quality(
+            data["variant"], is_sdk_based, usage_count, responsiveness
+        )
         util._write_yaml(yaml_file, data)
+
 
 @app.command()
 def add_airbyte(repo_url: str = None, auto_accept: bool = typer.Option(False)):

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -77,6 +77,8 @@ def update_quality(
     util = Utilities(True)
     usage_metrics = util._read_yaml(metrics_file_path)
     for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
+        if yaml_file.split("/")[-3] not in ("extractors", "loaders"):
+            continue
         data = util._read_yaml(yaml_file)
         is_sdk_based = False
 

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -69,6 +69,23 @@ def update_sdk(
     util = Utilities(auto_accept)
     util.update_sdk(repo_url, plugin_name)
 
+@app.command()
+def update_quality(
+    metrics_file_path: str,
+):
+    util = Utilities(True)
+    usage_metrics = util._read_yaml(metrics_file_path)
+    for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
+        data = util._read_yaml(yaml_file)
+        is_sdk_based = False
+        
+        if "keywords" in data and "meltano_sdk" in data.get("keywords"):
+            is_sdk_based = True
+        usage_count = usage_metrics.get(data["repo"], {}).get("ALL_PROJECTS", 0)
+        # TODO: Calculate responsiveness
+        responsiveness = "high"
+        data["quality"] = MeltanoUtil.get_quality(data["variant"], is_sdk_based, usage_count, responsiveness)
+        util._write_yaml(yaml_file, data)
 
 @app.command()
 def add_airbyte(repo_url: str = None, auto_accept: bool = typer.Option(False)):

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -107,6 +107,7 @@ class MeltanoUtil:
 
     @staticmethod
     def _evaluate_community(variant, is_sdk_based, usage_count, responsiveness) -> bool:
+        legacy_partners = ["singer-io", "airbyte", "transferwise"]
         quality = "unknown"
         if is_sdk_based and usage_count >= 6 and responsiveness != "low":
             quality = "gold"
@@ -114,9 +115,11 @@ class MeltanoUtil:
             quality = "silver"
         elif usage_count >= 1 and responsiveness != "low":
             quality = "silver"
+        elif usage_count >= 6 and variant in legacy_partners:
+            quality = "silver"
         elif usage_count >= 1:
             quality = "bronze"
-        elif variant in ["singer-io", "airbyte"]:
+        elif variant in legacy_partners:
             quality = "bronze"
         return quality
 

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -88,46 +88,51 @@ class MeltanoUtil:
         return maintainer
 
     @staticmethod
+    def _evaluate_official(is_sdk_based, usage_count, responsiveness) -> bool:
+        quality = "bronze"
+        if is_sdk_based:
+            quality = "gold"
+        elif usage_count >= 1 and responsiveness != "low":
+            quality = "silver"
+        return quality
+
+    @staticmethod
+    def _evaluate_partner(is_sdk_based, usage_count, responsiveness) -> bool:
+        quality = "bronze"
+        if is_sdk_based:
+            quality = "gold"
+        elif usage_count >= 1 and responsiveness != "low":
+            quality = "silver"
+        return quality
+
+    @staticmethod
+    def _evaluate_community(is_sdk_based, usage_count, responsiveness) -> bool:
+        quality = "unknown"
+        if is_sdk_based and usage_count >= 6 and responsiveness != "low":
+            quality = "gold"
+        elif is_sdk_based:
+            quality = "silver"
+        elif usage_count >= 1 and responsiveness != "low":
+            quality = "silver"
+        elif usage_count >= 1 and responsiveness == "low":
+            quality = "bronze"
+        return quality
+
+    @staticmethod
     def get_quality(variant, is_sdk_based, usage_count, responsiveness):
         maintainer = MeltanoUtil._get_maintainer(variant)
-        quality = "unknown"
-
-        if maintainer == "official" and is_sdk_based:
-            quality = "gold"
-        elif maintainer == "official" and usage_count >= 1 and responsiveness != "low":
-            quality = "silver"
-        elif maintainer == "official":
-            quality = "bronze"
-
-        if maintainer == "partner" and is_sdk_based:
-            quality = "gold"
-        elif (
-            maintainer == "partner"
-            and usage_count >= 1
-            and responsiveness in ["medium", "high"]
-        ):
-            quality = "silver"
+        if maintainer == "official":
+            quality = MeltanoUtil._evaluate_official(
+                is_sdk_based, usage_count, responsiveness
+            )
         elif maintainer == "partner":
-            quality = "bronze"
-
-        if (
-            maintainer == "community"
-            and is_sdk_based
-            and usage_count >= 6
-            and responsiveness in ["medium", "high"]
-        ):
-            quality = "gold"
-        elif maintainer == "community" and is_sdk_based:
-            quality = "silver"
-        elif (
-            maintainer == "community"
-            and usage_count >= 1
-            and responsiveness in ["medium", "high"]
-        ):
-            quality = "silver"
-        elif maintainer == "community" and usage_count >= 1:
-            quality = "bronze"
-
+            quality = MeltanoUtil._evaluate_partner(
+                is_sdk_based, usage_count, responsiveness
+            )
+        elif maintainer == "community":
+            quality = MeltanoUtil._evaluate_community(
+                is_sdk_based, usage_count, responsiveness
+            )
         return quality
 
     @staticmethod

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -106,7 +106,7 @@ class MeltanoUtil:
         return quality
 
     @staticmethod
-    def _evaluate_community(is_sdk_based, usage_count, responsiveness) -> bool:
+    def _evaluate_community(variant, is_sdk_based, usage_count, responsiveness) -> bool:
         quality = "unknown"
         if is_sdk_based and usage_count >= 6 and responsiveness != "low":
             quality = "gold"
@@ -114,7 +114,9 @@ class MeltanoUtil:
             quality = "silver"
         elif usage_count >= 1 and responsiveness != "low":
             quality = "silver"
-        elif usage_count >= 1 and responsiveness == "low":
+        elif usage_count >= 1:
+            quality = "bronze"
+        elif variant in ["singer-io", "airbyte"]:
             quality = "bronze"
         return quality
 
@@ -131,7 +133,7 @@ class MeltanoUtil:
             )
         elif maintainer == "community":
             quality = MeltanoUtil._evaluate_community(
-                is_sdk_based, usage_count, responsiveness
+                variant, is_sdk_based, usage_count, responsiveness
             )
         return quality
 

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -76,7 +76,6 @@ class MeltanoUtil:
             )
             return json.loads(about_content.stdout)
 
-
     @staticmethod
     def _get_maintainer(
         variant,
@@ -87,14 +86,9 @@ class MeltanoUtil:
         elif variant in ["matatika", "autoidm", "hotglue", "hotgluexyz"]:
             maintainer = "partner"
         return maintainer
-        
+
     @staticmethod
-    def get_quality(
-        variant,
-        is_sdk_based,
-        usage_count,
-        responsiveness
-    ):
+    def get_quality(variant, is_sdk_based, usage_count, responsiveness):
         maintainer = MeltanoUtil._get_maintainer(variant)
         quality = "unknown"
 
@@ -102,13 +96,21 @@ class MeltanoUtil:
             quality = "gold"
         elif maintainer == "partner" and is_sdk_based:
             quality = "gold"
-        elif maintainer == "partner" and usage_count >= 1 and responsiveness in ["medium", "high"]:
+        elif (
+            maintainer == "partner"
+            and usage_count >= 1
+            and responsiveness in ["medium", "high"]
+        ):
             quality = "silver"
         elif maintainer == "partner":
             quality = "bronze"
         elif maintainer == "community" and is_sdk_based:
             quality = "silver"
-        elif maintainer == "community" and usage_count >= 1 and responsiveness in ["medium", "high"]:
+        elif (
+            maintainer == "community"
+            and usage_count >= 1
+            and responsiveness in ["medium", "high"]
+        ):
             quality = "silver"
         elif maintainer == "community" and usage_count >= 1:
             quality = "bronze"

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -76,6 +76,44 @@ class MeltanoUtil:
             )
             return json.loads(about_content.stdout)
 
+
+    @staticmethod
+    def _get_maintainer(
+        variant,
+    ):
+        maintainer = "community"
+        if variant in ["meltano", "meltanolabs"]:
+            maintainer = "official"
+        elif variant in ["matatika", "autoidm", "hotglue", "hotgluexyz"]:
+            maintainer = "partner"
+        return maintainer
+        
+    @staticmethod
+    def get_quality(
+        variant,
+        is_sdk_based,
+        usage_count,
+        responsiveness
+    ):
+        maintainer = MeltanoUtil._get_maintainer(variant)
+        quality = "unknown"
+
+        if maintainer == "official":
+            quality = "gold"
+        elif maintainer == "partner" and is_sdk_based:
+            quality = "gold"
+        elif maintainer == "partner" and usage_count >= 1 and responsiveness in ["medium", "high"]:
+            quality = "silver"
+        elif maintainer == "partner":
+            quality = "bronze"
+        elif maintainer == "community" and is_sdk_based:
+            quality = "silver"
+        elif maintainer == "community" and usage_count >= 1 and responsiveness in ["medium", "high"]:
+            quality = "silver"
+        elif maintainer == "community" and usage_count >= 1:
+            quality = "bronze"
+        return quality
+
     @staticmethod
     def _get_label(name):
         new_label = []

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -92,9 +92,14 @@ class MeltanoUtil:
         maintainer = MeltanoUtil._get_maintainer(variant)
         quality = "unknown"
 
-        if maintainer == "official":
+        if maintainer == "official" and is_sdk_based:
             quality = "gold"
-        elif maintainer == "partner" and is_sdk_based:
+        elif maintainer == "official" and usage_count >= 1 and responsiveness != "low":
+            quality = "silver"
+        elif maintainer == "official":
+            quality = "bronze"
+
+        if maintainer == "partner" and is_sdk_based:
             quality = "gold"
         elif (
             maintainer == "partner"
@@ -104,6 +109,14 @@ class MeltanoUtil:
             quality = "silver"
         elif maintainer == "partner":
             quality = "bronze"
+
+        if (
+            maintainer == "community"
+            and is_sdk_based
+            and usage_count >= 6
+            and responsiveness in ["medium", "high"]
+        ):
+            quality = "gold"
         elif maintainer == "community" and is_sdk_based:
             quality = "silver"
         elif (
@@ -114,6 +127,7 @@ class MeltanoUtil:
             quality = "silver"
         elif maintainer == "community" and usage_count >= 1:
             quality = "bronze"
+
         return quality
 
     @staticmethod

--- a/tests/test_meltano_utils.py
+++ b/tests/test_meltano_utils.py
@@ -470,6 +470,12 @@ def test_sdk_about_parsing_skip_default_dates():
         [["foobar", False, 6, "low"], "bronze"],
         [["foobar", False, 6, "medium"], "silver"],
         [["foobar", False, 6, "high"], "silver"],
+
+        # Singer
+        [["singer-io", False, 0, "low"], "bronze"],
+
+        # Airbyte
+        [["airbyte", False, 0, "low"], "bronze"],
     ]
 )
 def test_get_quality(input, expected):

--- a/tests/test_meltano_utils.py
+++ b/tests/test_meltano_utils.py
@@ -421,15 +421,15 @@ def test_sdk_about_parsing_skip_default_dates():
         [["meltanolabs", True, 6, "low"], "gold"],
         [["meltanolabs", True, 6, "medium"], "gold"],
         [["meltanolabs", True, 6, "high"], "gold"],
-        [["meltanolabs", False, 0, "low"], "gold"],
-        [["meltanolabs", False, 0, "medium"], "gold"],
-        [["meltanolabs", False, 0, "high"], "gold"],
-        [["meltanolabs", False, 1, "low"], "gold"],
-        [["meltanolabs", False, 1, "medium"], "gold"],
-        [["meltanolabs", False, 1, "high"], "gold"],
-        [["meltanolabs", False, 6, "low"], "gold"],
-        [["meltanolabs", False, 6, "medium"], "gold"],
-        [["meltanolabs", False, 6, "high"], "gold"],
+        [["meltanolabs", False, 0, "low"], "bronze"],
+        [["meltanolabs", False, 0, "medium"], "bronze"],
+        [["meltanolabs", False, 0, "high"], "bronze"],
+        [["meltanolabs", False, 1, "low"], "bronze"],
+        [["meltanolabs", False, 1, "medium"], "silver"],
+        [["meltanolabs", False, 1, "high"], "silver"],
+        [["meltanolabs", False, 6, "low"], "bronze"],
+        [["meltanolabs", False, 6, "medium"], "silver"],
+        [["meltanolabs", False, 6, "high"], "silver"],
 
         # Partner
         [["matatika", True, 0, "low"], "gold"],
@@ -459,8 +459,8 @@ def test_sdk_about_parsing_skip_default_dates():
         [["foobar", True, 1, "medium"], "silver"],
         [["foobar", True, 1, "high"], "silver"],
         [["foobar", True, 6, "low"], "silver"],
-        [["foobar", True, 6, "medium"], "silver"],
-        [["foobar", True, 6, "high"], "silver"],
+        [["foobar", True, 6, "medium"], "gold"],
+        [["foobar", True, 6, "high"], "gold"],
         [["foobar", False, 0, "low"], "unknown"],
         [["foobar", False, 0, "medium"], "unknown"],
         [["foobar", False, 0, "high"], "unknown"],
@@ -473,4 +473,4 @@ def test_sdk_about_parsing_skip_default_dates():
     ]
 )
 def test_get_quality(input, expected):
-    assert MeltanoUtil.get_quality(*input) == expected
+    assert MeltanoUtil.get_quality(*input) == expected, input

--- a/tests/test_meltano_utils.py
+++ b/tests/test_meltano_utils.py
@@ -406,3 +406,71 @@ def test_sdk_about_parsing_skip_default_dates():
             "kind": "date_iso8601",
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        # Official
+        [["meltanolabs", True, 0, "low"], "gold"],
+        [["meltanolabs", True, 0, "medium"], "gold"],
+        [["meltanolabs", True, 0, "high"], "gold"],
+        [["meltanolabs", True, 1, "low"], "gold"],
+        [["meltanolabs", True, 1, "medium"], "gold"],
+        [["meltanolabs", True, 1, "high"], "gold"],
+        [["meltanolabs", True, 6, "low"], "gold"],
+        [["meltanolabs", True, 6, "medium"], "gold"],
+        [["meltanolabs", True, 6, "high"], "gold"],
+        [["meltanolabs", False, 0, "low"], "gold"],
+        [["meltanolabs", False, 0, "medium"], "gold"],
+        [["meltanolabs", False, 0, "high"], "gold"],
+        [["meltanolabs", False, 1, "low"], "gold"],
+        [["meltanolabs", False, 1, "medium"], "gold"],
+        [["meltanolabs", False, 1, "high"], "gold"],
+        [["meltanolabs", False, 6, "low"], "gold"],
+        [["meltanolabs", False, 6, "medium"], "gold"],
+        [["meltanolabs", False, 6, "high"], "gold"],
+
+        # Partner
+        [["matatika", True, 0, "low"], "gold"],
+        [["matatika", True, 0, "medium"], "gold"],
+        [["matatika", True, 0, "high"], "gold"],
+        [["matatika", True, 1, "low"], "gold"],
+        [["matatika", True, 1, "medium"], "gold"],
+        [["matatika", True, 1, "high"], "gold"],
+        [["matatika", True, 6, "low"], "gold"],
+        [["matatika", True, 6, "medium"], "gold"],
+        [["matatika", True, 6, "high"], "gold"],
+        [["matatika", False, 0, "low"], "bronze"],
+        [["matatika", False, 0, "medium"], "bronze"],
+        [["matatika", False, 0, "high"], "bronze"],
+        [["matatika", False, 1, "low"], "bronze"],
+        [["matatika", False, 1, "medium"], "silver"],
+        [["matatika", False, 1, "high"], "silver"],
+        [["matatika", False, 6, "low"], "bronze"],
+        [["matatika", False, 6, "medium"], "silver"],
+        [["matatika", False, 6, "high"], "silver"],
+
+        # Community
+        [["foobar", True, 0, "low"], "silver"],
+        [["foobar", True, 0, "medium"], "silver"],
+        [["foobar", True, 0, "high"], "silver"],
+        [["foobar", True, 1, "low"], "silver"],
+        [["foobar", True, 1, "medium"], "silver"],
+        [["foobar", True, 1, "high"], "silver"],
+        [["foobar", True, 6, "low"], "silver"],
+        [["foobar", True, 6, "medium"], "silver"],
+        [["foobar", True, 6, "high"], "silver"],
+        [["foobar", False, 0, "low"], "unknown"],
+        [["foobar", False, 0, "medium"], "unknown"],
+        [["foobar", False, 0, "high"], "unknown"],
+        [["foobar", False, 1, "low"], "bronze"],
+        [["foobar", False, 1, "medium"], "silver"],
+        [["foobar", False, 1, "high"], "silver"],
+        [["foobar", False, 6, "low"], "bronze"],
+        [["foobar", False, 6, "medium"], "silver"],
+        [["foobar", False, 6, "high"], "silver"],
+    ]
+)
+def test_get_quality(input, expected):
+    assert MeltanoUtil.get_quality(*input) == expected

--- a/tests/test_meltano_utils.py
+++ b/tests/test_meltano_utils.py
@@ -476,6 +476,11 @@ def test_sdk_about_parsing_skip_default_dates():
 
         # Airbyte
         [["airbyte", False, 0, "low"], "bronze"],
+
+        # Transferwise
+        [["transferwise", False, 6, "low"], "silver"],
+        [["transferwise", False, 1, "medium"], "silver"],
+        [["transferwise", False, 0, "low"], "bronze"],
     ]
 )
 def test_get_quality(input, expected):

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ isolated_build = true
 
 [testenv]
 allowlist_externals = poetry
+passenv = HUB_ROOT_PATH
 
 commands =
     poetry install -v


### PR DESCRIPTION
- new command for updating all quality attributes based on new inputs
- uses https://docs.meltano.com/cloud/connectors#connector-quality-matrix as a guide but has some slightly different opinions when it requires judgement
- tests to assert the expectations. I included every variation we had.
- this reads off the hub metrics file provided by Squared
- currently responsiveness is hard coded but we can add it to the hub metrics file
- partners are only matatika/autoidm/hotglue as of now

Other:
- I had to update the github action to clone the hub and pass in the HUB_ROOT_PATH for the tests to pass

@tayloramurphy let me know if you disagree with any of the test cases. Its trivial to update them and refresh https://github.com/meltano/hub/pull/1347.