### PR TITLE
Refactor for migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ raw_data/
 .coverage
 .vscode/settings.json
 http_cache.sqlite
+sdk.csv

--- a/README.md
+++ b/README.md
@@ -45,19 +45,24 @@ $ hub-utils [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `add`
-* `add-airbyte`
-* `add-hotglue`
-* `download-metadata`: NOTE: USED FOR AUTOMATION ONLY
-* `extract-sdk-metadata-to-s3`: NOTE: USED FOR AUTOMATION ONLY
-* `get-variant-names`: NOTE: USED FOR AUTOMATION ONLY
-* `merge-metadata`: NOTE: USED FOR AUTOMATION ONLY
-* `sdk-variants-as-csv`: This command will generate a `sdk.csv` CSV...
-* `update-definition`
-* `update-quality`
-* `upload-airbyte`: NOTE: USED FOR AUTOMATION ONLY
+* `add`: Add a new tap or target to the hub.
+* `download-metadata`: NOTE: USED FOR...
+* `extract-sdk-metadata-to-s3`: NOTE: USED FOR...
+* `get-variant-names`: NOTE: USED FOR...
+* `merge-metadata`: NOTE: USED FOR...
+* `sdk-variants-as-csv`: Generate a `sdk.csv` CSV file in the...
+* `update-definition`: Update the definition of a tap or target...
+* `update-quality`: Update the quality of all taps and targets...
+* `upload-airbyte`: NOTE: USED FOR...
 
 ## `hub-utils add`
+
+Add a new tap or target to the hub.
+It will prompt you for any attributes that need input.
+
+If the plugin is SDK based it will do its best to install the plugin and scrape the settings for you.
+It will prompt you for any missing attributes. If its not SDK based it will prompt you for
+settings 1 at a time and help you by suggesting defaults that you can accept or override.
 
 **Usage**:
 
@@ -71,39 +76,11 @@ $ hub-utils add [OPTIONS]
 * `--auto-accept / --no-auto-accept`: [default: no-auto-accept]
 * `--help`: Show this message and exit.
 
-## `hub-utils add-airbyte`
-
-**Usage**:
-
-```console
-$ hub-utils add-airbyte [OPTIONS]
-```
-
-**Options**:
-
-* `--repo-url TEXT`
-* `--auto-accept / --no-auto-accept`: [default: no-auto-accept]
-* `--help`: Show this message and exit.
-
-## `hub-utils add-hotglue`
-
-**Usage**:
-
-```console
-$ hub-utils add-hotglue [OPTIONS]
-```
-
-**Options**:
-
-* `--repo-url TEXT`
-* `--auto-accept / --no-auto-accept`: [default: no-auto-accept]
-* `--help`: Show this message and exit.
-
 ## `hub-utils download-metadata`
 
-NOTE: USED FOR AUTOMATION ONLY
+NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
-This command will download the latest metadata for the given variants from S3.
+Download the latest metadata for the given variants from S3.
 
 **Usage**:
 
@@ -122,9 +99,9 @@ $ hub-utils download-metadata [OPTIONS] LOCAL_PATH
 
 ## `hub-utils extract-sdk-metadata-to-s3`
 
-NOTE: USED FOR AUTOMATION ONLY
+NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
-This command will extract the SDK metadata for the given variants and upload them to S3.
+Extract the SDK metadata for the given variants and upload them to S3.
 
 **Usage**:
 
@@ -143,10 +120,10 @@ $ hub-utils extract-sdk-metadata-to-s3 [OPTIONS] VARIANT_PATH_LIST OUTPUT_DIR
 
 ## `hub-utils get-variant-names`
 
-NOTE: USED FOR AUTOMATION ONLY
+NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
-This command will get all the variant names for a given set of filters.
-The list will be formatted as escapped JSON to be used by Github Actions.
+Generate a list of variant names for a given set of filters.
+The list will be formatted as escaped JSON to be used by Github Actions.
 
 **Usage**:
 
@@ -166,9 +143,9 @@ $ hub-utils get-variant-names [OPTIONS] HUB_ROOT
 
 ## `hub-utils merge-metadata`
 
-NOTE: USED FOR AUTOMATION ONLY
+NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
-This command will merge the latest SDK metadata from S3 with the existing hub
+Merge the latest SDK metadata from S3 with the existing hub
 
 **Usage**:
 
@@ -188,7 +165,7 @@ $ hub-utils merge-metadata [OPTIONS] HUB_ROOT LOCAL_PATH
 
 ## `hub-utils sdk-variants-as-csv`
 
-This command will generate a `sdk.csv` CSV file in the current directory containing the following columns:
+Generate a `sdk.csv` CSV file in the current directory containing the following columns:
 plugin_type, name, variant, sdk
 
 **Usage**:
@@ -202,6 +179,13 @@ $ hub-utils sdk-variants-as-csv [OPTIONS]
 * `--help`: Show this message and exit.
 
 ## `hub-utils update-definition`
+
+Update the definition of a tap or target in the hub.
+
+Similar to the `add` command it will try to auto update using SDK settings or prompt you for input.
+When merging it will use the following rules:
+- if SDK setting description is empty it prefers the existing description
+- if the existing description longer than the scraped setting and has new lines then its likely manually overridden on the hub so prefer that one.
 
 **Usage**:
 
@@ -217,6 +201,12 @@ $ hub-utils update-definition [OPTIONS]
 * `--help`: Show this message and exit.
 
 ## `hub-utils update-quality`
+
+Update the quality of all taps and targets on the hub.
+
+This command accepts a path to the
+[variant_metrics.yml](https://github.com/meltano/hub/blob/main/_data/variant_metrics.yml)
+yaml file, make sure its the most up to date version likely sourced from S3.
 
 **Usage**:
 
@@ -234,9 +224,9 @@ $ hub-utils update-quality [OPTIONS] METRICS_FILE_PATH
 
 ## `hub-utils upload-airbyte`
 
-NOTE: USED FOR AUTOMATION ONLY
+NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
-This command will upload the given Airbyte artifacts to S3.
+Upload the given Airbyte artifacts to S3.
 
 **Usage**:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `hub-utils`
 
-[MeltanoHub](https://hub.meltano.com/) Utilities - A utility CLI intended to streamline the
-work needed to maintain MeltanoHub.
+[MeltanoHub](https://hub.meltano.com/) Utilities - A utility CLI intended
+to streamline the work needed to maintain MeltanoHub.
 
 **Installation**
 
@@ -61,9 +61,10 @@ $ hub-utils [OPTIONS] COMMAND [ARGS]...
 Add a new tap or target to the hub.
 It will prompt you for any attributes that need input.
 
-If the plugin is SDK based it will do its best to install the plugin and scrape the settings for you.
-It will prompt you for any missing attributes. If its not SDK based it will prompt you for
-settings 1 at a time and help you by suggesting defaults that you can accept or override.
+If the plugin is SDK based it will do its best to install the plugin and scrape
+the settings for you. It will prompt you for any missing attributes. If its not
+SDK based it will prompt you for settings 1 at a time and help you by suggesting
+defaults that you can accept or override.
 
 **Usage**:
 
@@ -79,8 +80,8 @@ $ hub-utils add [OPTIONS]
 
 ## `hub-utils download-metadata`
 
-NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
-
+NOTE: USED FOR
+[AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 Download the latest metadata for the given variants from S3.
 
 **Usage**:
@@ -100,7 +101,8 @@ $ hub-utils download-metadata [OPTIONS] LOCAL_PATH
 
 ## `hub-utils extract-sdk-metadata-to-s3`
 
-NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+NOTE: USED FOR
+[AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
 Extract the SDK metadata for the given variants and upload them to S3.
 
@@ -121,7 +123,8 @@ $ hub-utils extract-sdk-metadata-to-s3 [OPTIONS] VARIANT_PATH_LIST OUTPUT_DIR
 
 ## `hub-utils get-variant-names`
 
-NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+NOTE: USED FOR
+[AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
 Generate a list of variant names for a given set of filters.
 The list will be formatted as escaped JSON to be used by Github Actions.
@@ -144,7 +147,8 @@ $ hub-utils get-variant-names [OPTIONS] HUB_ROOT
 
 ## `hub-utils merge-metadata`
 
-NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+NOTE: USED FOR
+[AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
 Merge the latest SDK metadata from S3 with the existing hub
 
@@ -166,7 +170,8 @@ $ hub-utils merge-metadata [OPTIONS] HUB_ROOT LOCAL_PATH
 
 ## `hub-utils sdk-variants-as-csv`
 
-Generate a `sdk.csv` CSV file in the current directory containing the following columns:
+Generate a `sdk.csv` CSV file in the current directory containing the following
+columns:
 plugin_type, name, variant, sdk
 
 **Usage**:
@@ -183,10 +188,11 @@ $ hub-utils sdk-variants-as-csv [OPTIONS]
 
 Update the definition of a tap or target in the hub.
 
-Similar to the `add` command it will try to auto update using SDK settings or prompt you for input.
-When merging it will use the following rules:
+Similar to the `add` command it will try to auto update using SDK settings or prompt
+you for input. When merging it will use the following rules:
 - if SDK setting description is empty it prefers the existing description
-- if the existing description longer than the scraped setting and has new lines then its likely manually overridden on the hub so prefer that one.
+- if the existing description longer than the scraped setting and has new lines
+    then its likely manually overridden on the hub so prefer that one.
 
 **Usage**:
 
@@ -205,8 +211,8 @@ $ hub-utils update-definition [OPTIONS]
 
 Update the quality of all taps and targets on the hub.
 
-This command accepts a path to the
-[variant_metrics.yml](https://github.com/meltano/hub/blob/main/_data/variant_metrics.yml)
+This command accepts a path to the [variant_metrics.yml]
+(https://github.com/meltano/hub/blob/main/_data/variant_metrics.yml)
 yaml file, make sure its the most up to date version likely sourced from S3.
 
 **Usage**:
@@ -225,7 +231,8 @@ $ hub-utils update-quality [OPTIONS] METRICS_FILE_PATH
 
 ## `hub-utils upload-airbyte`
 
-NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+NOTE: USED FOR
+[AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
 Upload the given Airbyte artifacts to S3.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,32 @@
 MeltanoHub Utilities - A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
 
 ## Installation
+
 ```
 export HUB_ROOT_PATH='/Users/meltano/hub'
 
 poetry install
 poetry run hub-utils --help
+```
+
+## Tests
+
+```bash
+poetry run pytest -v
+
+poetry run pytest -v tests/test_core.py::test_sdk_about_parsing_1
+```
+
+## Refreshing This README
+
+The CLI is auto documenting so put all content in the CLI modules
+and this will use [typer-cli](https://typer.tiangolo.com/typer-cli/) utilities
+to render them as markdown.
+
+Run the following command:
+
+```bash
+poetry run typer hub_utils/main.py utils docs --name hub-utils --output README.md
 ```
 
 **Usage**:

--- a/README.md
+++ b/README.md
@@ -1,57 +1,259 @@
-# hub-utils
+# `hub-utils`
 
-## Add
+MeltanoHub Utilities - A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
 
-A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
-
+## Installation
 ```
-export HUB_ROOT_PATH='/Users/pnadolny/Documents/Git/GitHub/meltano/hub'
+export HUB_ROOT_PATH='/Users/meltano/hub'
 
 poetry install
-poetry run hub_utils --help
-
-poetry run hub_utils add https://github.com/MeltanoLabs/tap-google-analytics
-poetry run hub_utils add https://github.com/MeltanoLabs/tap-google-analytics --auto-accept
+poetry run hub-utils --help
 ```
 
-## Bulk Add
+**Usage**:
 
-This will iterate all reo_urls in a CSV file and prompt as it goes through.
-After writing output it excludes the repo_url from an output CSV so you can pause iterating and restart. If skipped or added, it shouldnt prompt again.
-
-
-```
-poetry run hub_utils add-bulk /path/to/csv_file
+```console
+$ hub-utils [OPTIONS] COMMAND [ARGS]...
 ```
 
-## Add Airbyte
+**Options**:
 
+* `--install-completion`: Install completion for the current shell.
+* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `add`
+* `add-airbyte`
+* `add-hotglue`
+* `download-metadata`
+* `extract-metadata`
+* `extract-sdk-metadata-to-s3`
+* `get-variant-names`
+* `merge-metadata`
+* `refresh-sdk-variants`
+* `sdk-variants-as-csv`
+* `translate-sdk`
+* `update-definition`
+* `update-quality`
+* `upload-airbyte`
+
+## `hub-utils add`
+
+**Usage**:
+
+```console
+$ hub-utils add [OPTIONS]
 ```
-poetry run hub_utils add-airbyte
+
+**Options**:
+
+* `--repo-url TEXT`
+* `--auto-accept / --no-auto-accept`: [default: no-auto-accept]
+* `--help`: Show this message and exit.
+
+## `hub-utils add-airbyte`
+
+**Usage**:
+
+```console
+$ hub-utils add-airbyte [OPTIONS]
 ```
 
+**Options**:
 
-### Update SDK
+* `--repo-url TEXT`
+* `--auto-accept / --no-auto-accept`: [default: no-auto-accept]
+* `--help`: Show this message and exit.
 
+## `hub-utils add-hotglue`
+
+**Usage**:
+
+```console
+$ hub-utils add-hotglue [OPTIONS]
 ```
-poetry run hub_utils update-sdk --repo-url https://github.com/MeltanoLabs/tap-snowflake --auto-accept
+
+**Options**:
+
+* `--repo-url TEXT`
+* `--auto-accept / --no-auto-accept`: [default: no-auto-accept]
+* `--help`: Show this message and exit.
+
+## `hub-utils download-metadata`
+
+**Usage**:
+
+```console
+$ hub-utils download-metadata [OPTIONS] LOCAL_PATH
 ```
 
-### Refresh All SDK-based Variants
+**Arguments**:
 
-```
-poetry run hub_utils refresh-sdk-variants --starting-yaml="/_data/meltano/extractors/tap-zendesk-sell/leag.yml"
+* `LOCAL_PATH`: [required]
+
+**Options**:
+
+* `--variant-path-list TEXT`
+* `--help`: Show this message and exit.
+
+## `hub-utils extract-metadata`
+
+**Usage**:
+
+```console
+$ hub-utils extract-metadata [OPTIONS] OUTPUT_DIR
 ```
 
-### Export All SDK-based Metadata
+**Arguments**:
 
-```
-poetry run hub_utils extract-metadata --output-dir=/Users/pnadolny/Documents/Git/GitHub/pnadolny/hub-utils/data
-```
-## Tests
+* `OUTPUT_DIR`: [required]
 
-```bash
-poetry run pytest -v
+**Options**:
 
-poetry run pytest -v tests/test_core.py::test_sdk_about_parsing_1
+* `--starting-yaml TEXT`
+* `--help`: Show this message and exit.
+
+## `hub-utils extract-sdk-metadata-to-s3`
+
+**Usage**:
+
+```console
+$ hub-utils extract-sdk-metadata-to-s3 [OPTIONS] VARIANT_PATH_LIST OUTPUT_DIR
 ```
+
+**Arguments**:
+
+* `VARIANT_PATH_LIST`: [required]
+* `OUTPUT_DIR`: [required]
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `hub-utils get-variant-names`
+
+**Usage**:
+
+```console
+$ hub-utils get-variant-names [OPTIONS] HUB_ROOT
+```
+
+**Arguments**:
+
+* `HUB_ROOT`: [required]
+
+**Options**:
+
+* `--metadata-type TEXT`: [default: sdk]
+* `--plugin-type TEXT`
+* `--help`: Show this message and exit.
+
+## `hub-utils merge-metadata`
+
+**Usage**:
+
+```console
+$ hub-utils merge-metadata [OPTIONS] HUB_ROOT LOCAL_PATH
+```
+
+**Arguments**:
+
+* `HUB_ROOT`: [required]
+* `LOCAL_PATH`: [required]
+
+**Options**:
+
+* `--variant-path-list TEXT`
+* `--help`: Show this message and exit.
+
+## `hub-utils refresh-sdk-variants`
+
+**Usage**:
+
+```console
+$ hub-utils refresh-sdk-variants [OPTIONS]
+```
+
+**Options**:
+
+* `--starting-yaml TEXT`
+* `--help`: Show this message and exit.
+
+## `hub-utils sdk-variants-as-csv`
+
+**Usage**:
+
+```console
+$ hub-utils sdk-variants-as-csv [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `hub-utils translate-sdk`
+
+**Usage**:
+
+```console
+$ hub-utils translate-sdk [OPTIONS] VARIANT_PATH_LIST SDK_OUTPUT_PATH
+```
+
+**Arguments**:
+
+* `VARIANT_PATH_LIST`: [required]
+* `SDK_OUTPUT_PATH`: [required]
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `hub-utils update-definition`
+
+**Usage**:
+
+```console
+$ hub-utils update-definition [OPTIONS]
+```
+
+**Options**:
+
+* `--repo-url TEXT`
+* `--plugin-name TEXT`
+* `--auto-accept / --no-auto-accept`: [default: no-auto-accept]
+* `--help`: Show this message and exit.
+
+## `hub-utils update-quality`
+
+**Usage**:
+
+```console
+$ hub-utils update-quality [OPTIONS] METRICS_FILE_PATH
+```
+
+**Arguments**:
+
+* `METRICS_FILE_PATH`: [required]
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `hub-utils upload-airbyte`
+
+**Usage**:
+
+```console
+$ hub-utils upload-airbyte [OPTIONS] VARIANT_PATH_LIST ARTIFACT_NAME
+```
+
+**Arguments**:
+
+* `VARIANT_PATH_LIST`: [required]
+* `ARTIFACT_NAME`: [required]
+
+**Options**:
+
+* `--help`: Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ hub-utils [OPTIONS] COMMAND [ARGS]...
 * `get-variant-names`
 * `merge-metadata`
 * `refresh-sdk-variants`
-* `sdk-variants-csv`
+* `sdk-variants-as-csv`: This command will generate a `sdk.csv` CSV...
 * `translate-sdk`
 * `update-definition`
 * `update-quality`
@@ -202,12 +202,15 @@ $ hub-utils refresh-sdk-variants [OPTIONS]
 * `--starting-yaml TEXT`
 * `--help`: Show this message and exit.
 
-## `hub-utils sdk-variants-csv`
+## `hub-utils sdk-variants-as-csv`
+
+This command will generate a `sdk.csv` CSV file in the current directory containing the following columns:
+plugin_type, name, variant, sdk
 
 **Usage**:
 
 ```console
-$ hub-utils sdk-variants-csv [OPTIONS]
+$ hub-utils sdk-variants-as-csv [OPTIONS]
 ```
 
 **Options**:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `hub-utils`
 
-MeltanoHub Utilities - A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
+[MeltanoHub](https://hub.meltano.com/) Utilities - A utility CLI intended to streamline the
+work needed to maintain MeltanoHub.
 
 **Installation**
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,10 @@ $ hub-utils [OPTIONS] COMMAND [ARGS]...
 * `add-airbyte`
 * `add-hotglue`
 * `download-metadata`: NOTE: USED FOR AUTOMATION ONLY
-* `extract-metadata`
 * `extract-sdk-metadata-to-s3`: NOTE: USED FOR AUTOMATION ONLY
 * `get-variant-names`: NOTE: USED FOR AUTOMATION ONLY
 * `merge-metadata`: NOTE: USED FOR AUTOMATION ONLY
-* `refresh-sdk-variants`
 * `sdk-variants-as-csv`: This command will generate a `sdk.csv` CSV...
-* `translate-sdk`
 * `update-definition`
 * `update-quality`
 * `upload-airbyte`: NOTE: USED FOR AUTOMATION ONLY
@@ -121,23 +118,6 @@ $ hub-utils download-metadata [OPTIONS] LOCAL_PATH
 **Options**:
 
 * `--variant-path-list TEXT`
-* `--help`: Show this message and exit.
-
-## `hub-utils extract-metadata`
-
-**Usage**:
-
-```console
-$ hub-utils extract-metadata [OPTIONS] OUTPUT_DIR
-```
-
-**Arguments**:
-
-* `OUTPUT_DIR`: [required]
-
-**Options**:
-
-* `--starting-yaml TEXT`
 * `--help`: Show this message and exit.
 
 ## `hub-utils extract-sdk-metadata-to-s3`
@@ -206,19 +186,6 @@ $ hub-utils merge-metadata [OPTIONS] HUB_ROOT LOCAL_PATH
 * `--variant-path-list TEXT`
 * `--help`: Show this message and exit.
 
-## `hub-utils refresh-sdk-variants`
-
-**Usage**:
-
-```console
-$ hub-utils refresh-sdk-variants [OPTIONS]
-```
-
-**Options**:
-
-* `--starting-yaml TEXT`
-* `--help`: Show this message and exit.
-
 ## `hub-utils sdk-variants-as-csv`
 
 This command will generate a `sdk.csv` CSV file in the current directory containing the following columns:
@@ -229,23 +196,6 @@ plugin_type, name, variant, sdk
 ```console
 $ hub-utils sdk-variants-as-csv [OPTIONS]
 ```
-
-**Options**:
-
-* `--help`: Show this message and exit.
-
-## `hub-utils translate-sdk`
-
-**Usage**:
-
-```console
-$ hub-utils translate-sdk [OPTIONS] VARIANT_PATH_LIST SDK_OUTPUT_PATH
-```
-
-**Arguments**:
-
-* `VARIANT_PATH_LIST`: [required]
-* `SDK_OUTPUT_PATH`: [required]
 
 **Options**:
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ $ hub-utils [OPTIONS] COMMAND [ARGS]...
 * `add`
 * `add-airbyte`
 * `add-hotglue`
-* `download-metadata`
+* `download-metadata`: NOTE: USED FOR AUTOMATION ONLY
 * `extract-metadata`
-* `extract-sdk-metadata-to-s3`
-* `get-variant-names`
-* `merge-metadata`
+* `extract-sdk-metadata-to-s3`: NOTE: USED FOR AUTOMATION ONLY
+* `get-variant-names`: NOTE: USED FOR AUTOMATION ONLY
+* `merge-metadata`: NOTE: USED FOR AUTOMATION ONLY
 * `refresh-sdk-variants`
 * `sdk-variants-as-csv`: This command will generate a `sdk.csv` CSV...
 * `translate-sdk`
 * `update-definition`
 * `update-quality`
-* `upload-airbyte`
+* `upload-airbyte`: NOTE: USED FOR AUTOMATION ONLY
 
 ## `hub-utils add`
 
@@ -104,6 +104,10 @@ $ hub-utils add-hotglue [OPTIONS]
 
 ## `hub-utils download-metadata`
 
+NOTE: USED FOR AUTOMATION ONLY
+
+This command will download the latest metadata for the given variants from S3.
+
 **Usage**:
 
 ```console
@@ -138,6 +142,10 @@ $ hub-utils extract-metadata [OPTIONS] OUTPUT_DIR
 
 ## `hub-utils extract-sdk-metadata-to-s3`
 
+NOTE: USED FOR AUTOMATION ONLY
+
+This command will extract the SDK metadata for the given variants and upload them to S3.
+
 **Usage**:
 
 ```console
@@ -154,6 +162,11 @@ $ hub-utils extract-sdk-metadata-to-s3 [OPTIONS] VARIANT_PATH_LIST OUTPUT_DIR
 * `--help`: Show this message and exit.
 
 ## `hub-utils get-variant-names`
+
+NOTE: USED FOR AUTOMATION ONLY
+
+This command will get all the variant names for a given set of filters.
+The list will be formatted as escapped JSON to be used by Github Actions.
 
 **Usage**:
 
@@ -172,6 +185,10 @@ $ hub-utils get-variant-names [OPTIONS] HUB_ROOT
 * `--help`: Show this message and exit.
 
 ## `hub-utils merge-metadata`
+
+NOTE: USED FOR AUTOMATION ONLY
+
+This command will merge the latest SDK metadata from S3 with the existing hub
 
 **Usage**:
 
@@ -266,6 +283,10 @@ $ hub-utils update-quality [OPTIONS] METRICS_FILE_PATH
 * `--help`: Show this message and exit.
 
 ## `hub-utils upload-airbyte`
+
+NOTE: USED FOR AUTOMATION ONLY
+
+This command will upload the given Airbyte artifacts to S3.
 
 **Usage**:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MeltanoHub Utilities - A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
 
-## Installation
+**Installation**
 
 ```
 export HUB_ROOT_PATH='/Users/meltano/hub'
@@ -11,7 +11,7 @@ poetry install
 poetry run hub-utils --help
 ```
 
-## Tests
+**Tests**
 
 ```bash
 poetry run pytest -v
@@ -19,7 +19,7 @@ poetry run pytest -v
 poetry run pytest -v tests/test_core.py::test_sdk_about_parsing_1
 ```
 
-## Refreshing This README
+**Refreshing This README**
 
 The CLI is auto documenting so put all content in the CLI modules
 and this will use [typer-cli](https://typer.tiangolo.com/typer-cli/) utilities
@@ -54,7 +54,7 @@ $ hub-utils [OPTIONS] COMMAND [ARGS]...
 * `get-variant-names`
 * `merge-metadata`
 * `refresh-sdk-variants`
-* `sdk-variants-as-csv`
+* `sdk-variants-csv`
 * `translate-sdk`
 * `update-definition`
 * `update-quality`
@@ -202,12 +202,12 @@ $ hub-utils refresh-sdk-variants [OPTIONS]
 * `--starting-yaml TEXT`
 * `--help`: Show this message and exit.
 
-## `hub-utils sdk-variants-as-csv`
+## `hub-utils sdk-variants-csv`
 
 **Usage**:
 
 ```console
-$ hub-utils sdk-variants-as-csv [OPTIONS]
+$ hub-utils sdk-variants-csv [OPTIONS]
 ```
 
 **Options**:

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -38,7 +38,8 @@ SDK_SUFFIX_LIST = [
 @app.callback()
 def callback():
     """
-    MeltanoHub Utilities - A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
+    [MeltanoHub](https://hub.meltano.com/) Utilities - A utility CLI intended to streamline the
+    work needed to maintain MeltanoHub.
 
     **Installation**
 

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -245,6 +245,12 @@ def get_variant_names(
     # comma separated list
     plugin_type: str = None,
 ):
+    """
+    NOTE: USED FOR AUTOMATION ONLY
+
+    This command will get all the variant names for a given set of filters.
+    The list will be formatted as escapped JSON to be used by Github Actions.
+    """
     formatted_output = []
     util = Utilities(True)
     for yaml_file in find_all_yamls(f_path=f"{hub_root}/_data/meltano/"):
@@ -283,6 +289,11 @@ def extract_sdk_metadata_to_s3(
     variant_path_list: str,
     output_dir: str,
 ):
+    """
+    NOTE: USED FOR AUTOMATION ONLY
+
+    This command will extract the SDK metadata for the given variants and upload them to S3.
+    """
     util = Utilities(True)
     for yaml_file in variant_path_list.split(","):
         data = util._read_yaml(yaml_file)
@@ -318,6 +329,11 @@ def upload_airbyte(
     variant_path_list: str,
     artifact_name: str,
 ):
+    """
+    NOTE: USED FOR AUTOMATION ONLY
+
+    This command will upload the given Airbyte artifacts to S3.
+    """
     util = Utilities(True)
     yaml_file = variant_path_list
     for yaml_file in variant_path_list.split(","):
@@ -379,6 +395,11 @@ def download_metadata(
     local_path: str,
     variant_path_list: str = None,
 ):
+    """
+    NOTE: USED FOR AUTOMATION ONLY
+
+    This command will download the latest metadata for the given variants from S3.
+    """
     util = Utilities()
     s3 = S3()
     if not variant_path_list:
@@ -396,6 +417,11 @@ def merge_metadata(
     local_path: str,
     variant_path_list: str = None,
 ):
+    """
+    NOTE: USED FOR AUTOMATION ONLY
+
+    This command will merge the latest SDK metadata from S3 with the existing hub
+    """
     if not variant_path_list:
         variant_path_list = ",".join(
             [f"{hub_root}/_data/meltano/{suffix}.yml" for suffix in SDK_SUFFIX_LIST]

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -100,9 +100,7 @@ def add(repo_url: str = None, auto_accept: bool = typer.Option(False)):
             resp = requests.get(url)
             if resp.status_code != 200:
                 ext = ".png"
-                url = (
-                    f"https://s3.amazonaws.com/cdn.hotglue.xyz/images/logos/{service_name}{ext}"
-                )
+                url = f"https://s3.amazonaws.com/cdn.hotglue.xyz/images/logos/{service_name}{ext}"
                 resp = requests.get(url)
                 if resp.status_code != 200:
                     ext = ".jpeg"
@@ -122,10 +120,10 @@ def add(repo_url: str = None, auto_accept: bool = typer.Option(False)):
                             print(f"Unable to find logo for {service_name}")
                             return
             with open(
-                f"{util.hub_root}/static/assets/logos/extractors/{service_name}{ext}", "wb"
+                f"{util.hub_root}/static/assets/logos/extractors/{service_name}{ext}",
+                "wb",
             ) as f:
                 f.write(resp.content)
-
 
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -79,25 +79,16 @@ def add(repo_url: str = None, auto_accept: bool = typer.Option(False)):
 
 
 @app.command()
-def add_bulk(csv_path: str, auto_accept: bool = typer.Option(False)):
-    util = Utilities(auto_accept)
-    util.add_bulk(csv_path)
-
-
-@app.command()
-def update(repo_url: str = None, auto_accept: bool = typer.Option(False)):
-    util = Utilities(auto_accept)
-    util.update(repo_url)
-
-
-@app.command()
-def update_sdk(
+def update_definition(
     repo_url: str = None,
     plugin_name: str = None,
     auto_accept: bool = typer.Option(False),
 ):
     util = Utilities(auto_accept)
-    util.update_sdk(repo_url, plugin_name)
+    if util._prompt("is_meltano_sdk", True, type=bool):
+        util.update_sdk(repo_url, plugin_name)
+    else:
+        util.update(repo_url)
 
 
 @app.command()

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -159,7 +159,11 @@ def add_hotglue(repo_url: str = None, auto_accept: bool = typer.Option(False)):
 
 
 @app.command()
-def sdk_variants_csv():
+def sdk_variants_as_csv():
+    """
+    This command will generate a `sdk.csv` CSV file in the current directory containing the following columns:
+    plugin_type, name, variant, sdk
+    """
     util = Utilities(True)
     base_repo_path = os.path.dirname(os.path.dirname(__file__))
     with open(f"{base_repo_path}/sdk.csv", "w") as csvfile:

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -38,8 +38,8 @@ SDK_SUFFIX_LIST = [
 @app.callback()
 def callback():
     """
-    [MeltanoHub](https://hub.meltano.com/) Utilities - A utility CLI intended to streamline the
-    work needed to maintain MeltanoHub.
+    [MeltanoHub](https://hub.meltano.com/) Utilities - A utility CLI intended
+    to streamline the work needed to maintain MeltanoHub.
 
     **Installation**
 
@@ -79,9 +79,10 @@ def add(repo_url: str = None, auto_accept: bool = typer.Option(False)):
     Add a new tap or target to the hub.
     It will prompt you for any attributes that need input.
 
-    If the plugin is SDK based it will do its best to install the plugin and scrape the settings for you.
-    It will prompt you for any missing attributes. If its not SDK based it will prompt you for
-    settings 1 at a time and help you by suggesting defaults that you can accept or override.
+    If the plugin is SDK based it will do its best to install the plugin and scrape
+    the settings for you. It will prompt you for any missing attributes. If its not
+    SDK based it will prompt you for settings 1 at a time and help you by suggesting
+    defaults that you can accept or override.
     """
     util = Utilities(auto_accept)
     if "airbytehq/airbyte" in repo_url:
@@ -96,11 +97,17 @@ def add(repo_url: str = None, auto_accept: bool = typer.Option(False)):
             name = repo_url.split("/")[-1]
             service_name = name.replace("tap-", "").replace("target-", "")
             ext = ".svg"
-            url = f"https://s3.amazonaws.com/cdn.hotglue.xyz/images/logos/{service_name}{ext}"
+            url = (
+                "https://s3.amazonaws.com/cdn.hotglue.xyz/"
+                f"images/logos/{service_name}{ext}"
+            )
             resp = requests.get(url)
             if resp.status_code != 200:
                 ext = ".png"
-                url = f"https://s3.amazonaws.com/cdn.hotglue.xyz/images/logos/{service_name}{ext}"
+                url = (
+                    f"https://s3.amazonaws.com/cdn.hotglue.xyz/images/"
+                    f"logos/{service_name}{ext}"
+                )
                 resp = requests.get(url)
                 if resp.status_code != 200:
                     ext = ".jpeg"
@@ -135,10 +142,11 @@ def update_definition(
     """
     Update the definition of a tap or target in the hub.
 
-    Similar to the `add` command it will try to auto update using SDK settings or prompt you for input.
-    When merging it will use the following rules:
+    Similar to the `add` command it will try to auto update using SDK settings or prompt
+    you for input. When merging it will use the following rules:
     - if SDK setting description is empty it prefers the existing description
-    - if the existing description longer than the scraped setting and has new lines then its likely manually overridden on the hub so prefer that one.
+    - if the existing description longer than the scraped setting and has new lines
+        then its likely manually overridden on the hub so prefer that one.
     """
     util = Utilities(auto_accept)
     if util._prompt("is_meltano_sdk", True, type=bool):
@@ -154,8 +162,8 @@ def update_quality(
     """
     Update the quality of all taps and targets on the hub.
 
-    This command accepts a path to the
-    [variant_metrics.yml](https://github.com/meltano/hub/blob/main/_data/variant_metrics.yml)
+    This command accepts a path to the [variant_metrics.yml]
+    (https://github.com/meltano/hub/blob/main/_data/variant_metrics.yml)
     yaml file, make sure its the most up to date version likely sourced from S3.
     """
     util = Utilities(True)
@@ -180,7 +188,8 @@ def update_quality(
 @app.command()
 def sdk_variants_as_csv():
     """
-    Generate a `sdk.csv` CSV file in the current directory containing the following columns:
+    Generate a `sdk.csv` CSV file in the current directory containing the following
+    columns:
     plugin_type, name, variant, sdk
     """
     util = Utilities(True)
@@ -207,7 +216,8 @@ def get_variant_names(
     plugin_type: str = None,
 ):
     """
-    NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+    NOTE: USED FOR
+    [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
     Generate a list of variant names for a given set of filters.
     The list will be formatted as escaped JSON to be used by Github Actions.
@@ -251,7 +261,8 @@ def extract_sdk_metadata_to_s3(
     output_dir: str,
 ):
     """
-    NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+    NOTE: USED FOR
+    [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
     Extract the SDK metadata for the given variants and upload them to S3.
     """
@@ -291,7 +302,8 @@ def upload_airbyte(
     artifact_name: str,
 ):
     """
-    NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+    NOTE: USED FOR
+    [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
     Upload the given Airbyte artifacts to S3.
     """
@@ -321,8 +333,8 @@ def download_metadata(
     variant_path_list: str = None,
 ):
     """
-    NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
-
+    NOTE: USED FOR
+    [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
     Download the latest metadata for the given variants from S3.
     """
     util = Utilities()
@@ -343,7 +355,8 @@ def merge_metadata(
     variant_path_list: str = None,
 ):
     """
-    NOTE: USED FOR [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
+    NOTE: USED FOR
+    [AUTOMATION](https://github.com/meltano/hub/tree/main/.github/workflows) ONLY
 
     Merge the latest SDK metadata from S3 with the existing hub
     """

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -38,7 +38,37 @@ SDK_SUFFIX_LIST = [
 @app.callback()
 def callback():
     """
-    MeltanoHub Utilities
+    MeltanoHub Utilities - A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
+
+    ## Installation
+
+    ```
+    export HUB_ROOT_PATH='/Users/meltano/hub'
+
+    poetry install
+    poetry run hub-utils --help
+    ```
+
+    ## Tests
+
+    ```bash
+    poetry run pytest -v
+
+    poetry run pytest -v tests/test_core.py::test_sdk_about_parsing_1
+    ```
+
+    ## Refreshing This README
+
+    The CLI is auto documenting so put all content in the CLI modules
+    and this will use [typer-cli](https://typer.tiangolo.com/typer-cli/) utilities
+    to render them as markdown.
+
+    Run the following command:
+
+    ```bash
+    poetry run typer hub_utils/main.py utils docs --name hub-utils --output README.md
+    ```
+
     """
 
 

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -40,7 +40,7 @@ def callback():
     """
     MeltanoHub Utilities - A utility CLI intended to streamline the steps needed to add Singer taps/targets to [MeltanoHub](https://hub.meltano.com/).
 
-    ## Installation
+    **Installation**
 
     ```
     export HUB_ROOT_PATH='/Users/meltano/hub'
@@ -49,7 +49,7 @@ def callback():
     poetry run hub-utils --help
     ```
 
-    ## Tests
+    **Tests**
 
     ```bash
     poetry run pytest -v
@@ -57,7 +57,7 @@ def callback():
     poetry run pytest -v tests/test_core.py::test_sdk_about_parsing_1
     ```
 
-    ## Refreshing This README
+    **Refreshing This README**
 
     The CLI is auto documenting so put all content in the CLI modules
     and this will use [typer-cli](https://typer.tiangolo.com/typer-cli/) utilities

--- a/hub_utils/main.py
+++ b/hub_utils/main.py
@@ -181,64 +181,6 @@ def sdk_variants_as_csv():
 
 
 @app.command()
-def refresh_sdk_variants(
-    starting_yaml: str = None,
-):
-    util = Utilities(True)
-    start = False
-    failures = []
-    for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
-        data = util._read_yaml(yaml_file)
-        if yaml_file == f"{util.hub_root}{starting_yaml}":
-            start = True
-        elif not start:
-            print(f"Skipping SDK based: {yaml_file}")
-            continue
-        if "keywords" in data and "meltano_sdk" in data.get("keywords"):
-            print(f"Updating: {yaml_file}")
-            try:
-                util.update_sdk(data.get("repo"), data.get("name"))
-            except Exception as e:
-                failures.append(yaml_file)
-                print(e)
-
-
-@app.command()
-def extract_metadata(
-    output_dir: str,
-    starting_yaml: str = None,
-):
-    util = Utilities(True)
-    start = False
-    failures = []
-    for yaml_file in find_all_yamls(f_path=f"{util.hub_root}/_data/meltano/"):
-        data = util._read_yaml(yaml_file)
-        if not starting_yaml or yaml_file == f"{util.hub_root}{starting_yaml}":
-            start = True
-        elif not start:
-            print(f"Skipping SDK based: {yaml_file}")
-            continue
-        if "keywords" in data and "meltano_sdk" in data.get("keywords"):
-            print(f"Updating: {yaml_file}")
-            p_type = util.get_plugin_type(data.get("repo"))
-            p_name = data.get("name")
-            sdk_def = util._test(
-                p_name,
-                p_type,
-                data.get("pip_url"),
-                data.get("namespace"),
-                data.get("executable", p_name),
-                True,
-            )
-            if not sdk_def:
-                failures.append(yaml_file)
-                continue
-            file_name = os.path.basename(yaml_file).replace(".yml", ".json")
-            util._write_dict(f"{output_dir}/{p_type}/{p_name}/{file_name}", sdk_def)
-    print(failures)
-
-
-@app.command()
 def get_variant_names(
     hub_root: str,
     metadata_type: str = typer.Option("sdk"),
@@ -351,42 +293,6 @@ def upload_airbyte(
             S3().upload(s3_bucket, s3_file_path, artifact_name)
         else:
             print(f"Extract already exists: {s3_file_path}")
-
-
-@app.command()
-def translate_sdk(
-    variant_path_list: str,
-    sdk_output_path: str,
-):
-    util = Utilities(True)
-
-    for yaml_file in variant_path_list.split(","):
-        existing_def = util._read_yaml(yaml_file)
-        p_type, p_name, p_variant = yaml_file.split("/")[-3:]
-        p_variant = p_variant.replace(".yml", "")
-        suffix = f"{p_type}/{p_name}/{p_variant}"
-        local_file_path = f"{sdk_output_path}/{suffix}.json"
-        S3().download_latest(os.environ.get("AWS_S3_BUCKET"), suffix, local_file_path)
-
-        with open(local_file_path, "r") as f:
-            sdk_about = json.load(f)
-        (
-            settings,
-            settings_group_validation,
-            capabilities,
-        ) = MeltanoUtil._parse_sdk_about_settings(sdk_about)
-        new_def = util._merge_definitions(
-            existing_def,
-            settings,
-            util._string_to_literal(
-                util._scrape_keywords(True, existing_def.get("keywords"))
-            ),
-            existing_def.get("maintenance_status"),
-            capabilities,
-            settings_group_validation,
-        )
-        util._write_updated_def(p_name, p_variant, p_type, new_def)
-        util._reformat(p_type, p_name, p_variant)
 
 
 # GITHUB ACTIONS

--- a/hub_utils/meltano_util.py
+++ b/hub_utils/meltano_util.py
@@ -339,24 +339,3 @@ class MeltanoUtil:
                     i["description"] = i.get("const") or item.get("title")
                 fields.append(i)
         return fields
-
-
-if __name__ == "__main__":
-    m = MeltanoUtil()
-
-    # plugin_name = "tap-amazon-sp"
-    # namespace = "tap_amazon_sp",
-    # pip_url = "git+https://github.com/singer-io/tap-amazon-sp.git"
-    # plugin_type = "extractors"
-    # is_meltano_sdk = False
-
-    plugin_name = "tap-cqc-org-uk"
-    namespace = ("tap_cqc_org_uk",)
-    pip_url = "git+https://github.com/birdiecare/tap-cqc-org-uk.git"
-    plugin_type = "extractors"
-    is_meltano_sdk = False
-
-    MeltanoUtil.add(plugin_name, namespace, pip_url, plugin_type)
-    MeltanoUtil.help_test(plugin_name)
-    if is_meltano_sdk:
-        MeltanoUtil.sdk_about(plugin_name)

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -462,30 +462,6 @@ class Utilities:
                     continue
                 writer.writerow(row)
 
-    def add_bulk(self, csv_path: str):
-        edit_path = csv_path.split(".csv")[0] + "_edit.csv"
-        csv_list = []
-        repo_urls_to_delete = []
-        with open(csv_path, "r") as inp:
-            csv_list = [row for row in csv.reader(inp)]
-        for index, row in enumerate(csv_list):
-            if index == 0:
-                print(f"Skipping header {row}")
-                continue
-            repo_url = row[0]
-            plugin_definition = json.loads(row[5])
-            name_hash = hashlib.sha256(
-                self._get_plugin_name(repo_url).encode()
-            ).hexdigest()
-            do_add = self._prompt(
-                f"Add {repo_url} - {name_hash}?", default_val=True, type=bool
-            )
-            if do_add:
-                self.add(repo_url, definition_seed=plugin_definition)
-                self._prompt("Pausing to commit changes...hit any key to continue")
-            repo_urls_to_delete.append(repo_url)
-            self.delete_rows(repo_urls_to_delete, edit_path, csv_path)
-
     def _retrieve_def(self, plugin_name, plugin_variant, plugin_type):
         def_path = (
             f"{self.hub_root}/_data/meltano"

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -61,9 +61,7 @@ class Utilities:
     def __init__(self, auto_accept=False):
         self.yaml = YAML()
         self.auto_accept = auto_accept
-        self.hub_root = os.getenv(
-            "HUB_ROOT_PATH", self._prompt("Enter Hub Root Path")
-        )
+        self.hub_root = os.getenv("HUB_ROOT_PATH")
         self.default_variants_path = f"{self.hub_root}/_data/default_variants.yml"
         self.maintainers_path = f"{self.hub_root}/_data/maintainers.yml"
 

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -62,7 +62,7 @@ class Utilities:
         self.yaml = YAML()
         self.auto_accept = auto_accept
         self.hub_root = os.getenv(
-            "HUB_ROOT_PATH"
+            "HUB_ROOT_PATH", self._prompt("Enter Hub Root Path")
         )
         self.default_variants_path = f"{self.hub_root}/_data/default_variants.yml"
         self.maintainers_path = f"{self.hub_root}/_data/maintainers.yml"

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -62,7 +62,7 @@ class Utilities:
         self.yaml = YAML()
         self.auto_accept = auto_accept
         self.hub_root = os.getenv(
-            "HUB_ROOT_PATH", "/Users/pnadolny/Documents/Git/GitHub/meltano/hub"
+            "HUB_ROOT_PATH"
         )
         self.default_variants_path = f"{self.hub_root}/_data/default_variants.yml"
         self.maintainers_path = f"{self.hub_root}/_data/maintainers.yml"
@@ -692,11 +692,3 @@ class Utilities:
     def get_suffix(yaml_file):
         p_type, p_name, p_variant = os.path.splitext(yaml_file)[0].split("/")[-3:]
         return f"{p_type}/{p_name}/{p_variant}"
-
-
-if __name__ == "__main__":
-    util = Utilities(False)
-    util.add_airbyte()
-    # util.update_sdk("https://github.com/MeltanoLabs/tap-snowflake")
-    # util.update_sdk("https://github.com/hotgluexyz/tap-procore")
-    # util.add_bulk('/Users/pnadolny/Documents/Git/GitHub/pnadolny/hub-utils/other_scripts/export_edit.csv')

--- a/hub_utils/utilities.py
+++ b/hub_utils/utilities.py
@@ -1,6 +1,5 @@
 import ast
 import csv
-import hashlib
 import json
 import os
 import shutil

--- a/poetry.lock
+++ b/poetry.lock
@@ -601,11 +601,11 @@ testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (
 
 [[package]]
 name = "shellingham"
-version = "1.5.0.post1"
+version = "1.4.0"
 description = "Tool to Detect Surrounding Shell"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = "!=3.0,!=3.1,!=3.2,!=3.3,>=2.6"
 
 [[package]]
 name = "six"
@@ -674,6 +674,19 @@ all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
 doc = ["mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)"]
 test = ["black (>=22.3.0,<23.0.0)", "coverage (>=5.2,<6.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
+name = "typer-cli"
+version = "0.0.13"
+description = "Run Typer scripts with completion, without having to create a package, using Typer CLI."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = ">=0.4.3,<=0.5.0"
+shellingham = ">=1.3.2,<=1.4.0"
+typer = ">=0.4.0,<=0.7.0"
 
 [[package]]
 name = "types-pyyaml"
@@ -759,7 +772,7 @@ setuptools = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8.1,<3.11"
-content-hash = "f3722281748ee6ad6f229e8d7c9f5df010ee1ea983d8cc63d4983b5bc5556229"
+content-hash = "1c2710f7010af85feda73f3561bbe0ddab026c64577e182e81ac41746a915581"
 
 [metadata.files]
 attrs = [
@@ -1308,8 +1321,8 @@ setuptools = [
     {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
 ]
 shellingham = [
-    {file = "shellingham-1.5.0.post1-py2.py3-none-any.whl", hash = "sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744"},
-    {file = "shellingham-1.5.0.post1.tar.gz", hash = "sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28"},
+    {file = "shellingham-1.4.0-py2.py3-none-any.whl", hash = "sha256:536b67a0697f2e4af32ab176c00a50ac2899c5a05e0d8e2dadac8e58888283f9"},
+    {file = "shellingham-1.4.0.tar.gz", hash = "sha256:4855c2458d6904829bd34c299f11fdeed7cfefbf8a2c522e4caea6cd76b3171e"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1330,6 +1343,10 @@ tox = [
 typer = [
     {file = "typer-0.6.1-py3-none-any.whl", hash = "sha256:54b19e5df18654070a82f8c2aa1da456a4ac16a2a83e6dcd9f170e291c56338e"},
     {file = "typer-0.6.1.tar.gz", hash = "sha256:2d5720a5e63f73eaf31edaa15f6ab87f35f0690f8ca233017d7d23d743a91d73"},
+]
+typer-cli = [
+    {file = "typer_cli-0.0.13-py3-none-any.whl", hash = "sha256:5ae0f99dce8f8f9669137a2c98eb42485cd4412e0ec225c8eb29ce8ac3378731"},
+    {file = "typer_cli-0.0.13.tar.gz", hash = "sha256:f5b85764e56fb3fe835ed008ad5bc7db4961f7bcce1f1c1698ac46b6c5d9b86f"},
 ]
 types-pyyaml = [
     {file = "types-PyYAML-6.0.12.9.tar.gz", hash = "sha256:c51b1bd6d99ddf0aa2884a7a328810ebf70a4262c292195d3f4f9a0005f9eeb6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,14 @@ flake8 = "^6.0.0"
 pydocstyle = "^6.3.0"
 mypy = "^1.1.1"
 moto = "^4.1.6"
+typer-cli = "^0.0.13"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-hub_utils = 'hub_utils.main:app'
+hub-utils = 'hub_utils.main:app'
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/sample.sh
+++ b/sample.sh
@@ -1,6 +1,0 @@
-hub_root='/Users/pnadolny/Documents/Git/GitHub/meltano/hub'
-json_output_path='/Users/pnadolny/Documents/Git/GitHub/pnadolny/hub-utils/data'
-sdk_variants=$(poetry run hub_utils get-variant-names $hub_root)
-poetry run hub_utils extract-metadata-v2 "${sdk_variants}" $json_output_path
-echo "Uploading to S3..."
-poetry run hub_utils translate "${sdk_variants}" $json_output_path


### PR DESCRIPTION
Closes https://github.com/meltano/hub/issues/1281

- add typer-cli to auto generate docs + refresh readme
- add docs to every command
- combine all the add commands to one
- label all commands that are only for automation
- remove hub root path that was defaulted to my directory
- change to `hub-utils` instead of `hub_utils` since the docs recommend it with a dash. Now you can simply copy/paste
- remove some unused methods, there are definitely more. This is a follow up issue for that https://github.com/pnadolny13/hub-utils/issues/66